### PR TITLE
Allow setting default request headers

### DIFF
--- a/src/ClientBase.ts
+++ b/src/ClientBase.ts
@@ -49,7 +49,7 @@ class Client extends generated.Client {
         request: RequestInit
     ) => Promise<boolean>;
     private serviceBaseUrlDebug: string | undefined;
-
+    public defaultRequestHeaders?: Record<string, string>;
 
     constructor(options: ClientOptions, serviceBaseUrlDebug?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         // @ts-ignore
@@ -141,6 +141,11 @@ class Client extends generated.Client {
         const maxRetries = 1;
         let retryCount = 0;
         let shouldRetry = true;
+
+        if (this.defaultRequestHeaders) {
+            init.headers = Object.assign({}, this.defaultRequestHeaders, init.headers);
+        }
+
         while (retryCount <= maxRetries && shouldRetry) {
             const accessToken = await this.beforeFetchRequestAsync(url, init);
             const absoluteUrl = await this.getAbsoluteUrlFromToken(accessToken, url, init);

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ export class Client extends ClientBase {
         request: RequestInit
     ) => Promise<boolean>;
     private serviceBaseUrlDebug: string | undefined;
+    public defaultRequestHeaders?: Record<string, string>;
 
     constructor(options: ClientOptions, serviceBaseUrlDebug?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         // @ts-ignore
@@ -122,6 +123,11 @@ export class Client extends ClientBase {
         const maxRetries = 1;
         let retryCount = 0;
         let shouldRetry = true;
+
+        if (this.defaultRequestHeaders) {
+            init.headers = Object.assign({}, this.defaultRequestHeaders, init.headers);
+        }
+
         while (retryCount <= maxRetries && shouldRetry) {
             const accessToken = await this.beforeFetchRequestAsync(url, init);
             const absoluteUrl = await this.getAbsoluteUrlFromToken(accessToken, url, init);


### PR DESCRIPTION
Allow the option of setting default request headers. This can be useful for example if you want to send the Accept-Language header in every request