### PR TITLE
separate workflow into more steps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Test, build, and publish lf-repository-api-client
+name: lf-repository-api-client-js-CI
 
 on:
   push:
@@ -13,55 +13,15 @@ env:
   NPM_VERSION: "1.0.2"
 
 
-
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    environment: preview
-    env:
-        DEV_CA_PUBLIC_USE_INTEGRATION_TEST_ACCESS_KEY: ${{ secrets.DEV_CA_PUBLIC_USE_INTEGRATION_TEST_ACCESS_KEY }}
-        DEV_CA_PUBLIC_USE_TESTOAUTHSERVICEPRINCIPAL_SERVICE_PRINCIPAL_KEY:  ${{ secrets.DEV_CA_PUBLIC_USE_TESTOAUTHSERVICEPRINCIPAL_SERVICE_PRINCIPAL_KEY }}
-        DEV_CA_PUBLIC_USE_REPOSITORY_ID_1:  ${{ secrets.DEV_CA_PUBLIC_USE_REPOSITORY_ID_1 }}
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Echo build number
-        run: echo ${{github.run_id}}
-
-      - name: Setup Node.js environment
-        uses: actions/setup-node@v2.5.1
-        with:
-          node-version: '14'
-
-      - name: Npm tool install
-        run: npm install -g npm@8
-
-      - name: Npm ci
-        run: npm ci
-
-      - name: Npm test
-        run: npm run test:all
-
-      - name: Test Report
-        uses: dorny/test-reporter@v1
-        if: success() || failure()    # run this step even if previous step failed
-        with:
-          name: Jest Test Results
-          path: ./*.xml
-          reporter: jest-junit
-          only-summary: 'true'
-          fail-on-error: 'false'
   build:
-    needs: [ test ] # wait for tests to finish
     runs-on: ubuntu-latest
     env:
       NPM_TOKEN: dummy
       NPM_USERNAME: dummy
       NPM_EMAIL: dummy
       NPM_REGISTRY: dummy
-    outputs:
-      NpmBaseVersion: ${{ env.NpmPackageVersion }}
     steps:
       - uses: actions/checkout@v2
 
@@ -81,28 +41,6 @@ jobs:
 
       - name: Npm run build
         run: npm run build
-        
-      - name: Install typedoc
-        run: npm install typedoc
-
-      - name: Create temporary directory
-        run: mkdir -p ./docs_temp/${GITHUB_REF##*/}
-      
-      - name: Generate typedoc docs
-        run: npx typedoc ./src/index.ts --out ./docs_temp/${GITHUB_REF##*/} --excludePrivate
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2 # Use your bucket region here
-          
-      - name: Upload docs to S3 bucket
-        run: aws s3 sync ./docs_temp/${GITHUB_REF##*/}/ s3://apiserver-publish-client-library-docs/${GITHUB_REPOSITORY##*/}/docs/${GITHUB_REF##*/} --delete
-        
-      - name: delete temporary directory
-        run: rm -r ./docs_temp
 
       - name: Echo NPM package version
         run: echo ${{ env.NPM_VERSION }}
@@ -117,11 +55,115 @@ jobs:
             ./package.json
             ./README.md
             ./LICENSE
-  preview:
+
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v2.5.1
+        with:
+          node-version: '14'
+
+      - name: Npm tool install
+        run: npm install -g npm@8
+
+      - name: Npm ci
+        run: npm ci
+
+      - name: Npm test
+        env:
+          DEV_CA_PUBLIC_USE_INTEGRATION_TEST_ACCESS_KEY: ${{ secrets.DEV_CA_PUBLIC_USE_INTEGRATION_TEST_ACCESS_KEY }}
+          DEV_CA_PUBLIC_USE_TESTOAUTHSERVICEPRINCIPAL_SERVICE_PRINCIPAL_KEY:  ${{ secrets.DEV_CA_PUBLIC_USE_TESTOAUTHSERVICEPRINCIPAL_SERVICE_PRINCIPAL_KEY }}
+          DEV_CA_PUBLIC_USE_REPOSITORY_ID_1:  ${{ secrets.DEV_CA_PUBLIC_USE_REPOSITORY_ID_1 }}
+        run: npm run test:all
+
+      - name: Test Report
+        uses: dorny/test-reporter@v1
+        if: success() || failure()    # run this step even if previous step failed
+        with:
+          name: Jest Test Results
+          path: ./*.xml
+          reporter: jest-junit
+          only-summary: 'true'
+          fail-on-error: 'false'
+
+
+  build-documentation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v2.5.1
+        with:
+          node-version: '14'
+
+      - name: Npm tool install
+        run: npm install -g npm@8
+
+      - name: Npm ci
+        run: npm ci
+
+      - name: Npm run build
+        run: npm run build
+
+      - name: Install typedoc
+        run: npm install typedoc
+
+      - name: Create temporary directory
+        run: mkdir -p ./docs_temp/${{ github.ref_name }}
+
+      - name: Generate typedoc docs
+        run: npx typedoc ./src/index.ts --out ./docs_temp/${{ github.ref_name }} --excludePrivate
+
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v2.3.1
+        with:
+          name: documentation-artifact
+          # A file, directory or wildcard pattern that describes what to upload
+          path: ${{ github.workspace }}/docs_temp/${{ github.ref_name }}
+
+      - name: delete temporary directory
+        run: rm -r ./docs_temp
+
+
+  publish-documentation:
+    runs-on: ubuntu-latest
+    environment: documentation
+    if: ${{ github.run_attempt != 1 }}
+    needs: [ build, test, build-documentation ] # wait for build to finish
+    steps:
+    - name: Create temporary directory
+      run: mkdir -p ./docs_temp/${{ github.ref_name }}/
+
+    - name: Download a Build Artifact
+      uses: actions/download-artifact@v3.0.0
+      with:
+        name: documentation-artifact
+        path: ${{ github.workspace }}/docs_temp/${{ github.ref_name }}/
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-west-2 # Use your bucket region here
+
+    - name: Upload docs to S3 bucket
+      run: aws s3 sync ./docs_temp/${{ github.ref_name }}/ s3://apiserver-publish-client-library-docs/${{ github.event.repository.name }}/docs/${{ github.ref_name }} --delete
+
+    - name: Delete temporary directory
+      run: rm -r ./docs_temp/${{ github.ref_name }}/
+
+
+  publish-preview-package:
     runs-on: ubuntu-latest
     environment: preview
     if: ${{ github.run_attempt != 1 }}
-    needs: [ build ] # wait for build to finish
+    needs: [ build, test, build-documentation ] # wait for build to finish
     steps:
       - uses: actions/checkout@v2
         with:
@@ -165,18 +207,19 @@ jobs:
         with:
           tag: ${{ env.NpmPackageVersion }}
           commit_sha: ${{ github.sha }}
-          message: Workflow run ${{github.server_url}}/${{github.repository}}/actions/runs/${{ github.run_id}} 
+          message: Workflow run ${{github.server_url}}/${{github.repository}}/actions/runs/${{ github.run_id}}
 
-  production:
+
+  publish-production-package:
     runs-on: ubuntu-latest
     environment: production
     if: ${{ github.run_attempt != 1 }}
-    needs: [ build ]
+    needs: [ build, test, build-documentation ]
     steps:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.sha }}
-          
+
       - name: Download a Build Artifact
         uses: actions/download-artifact@v2.1.0
         with:
@@ -211,4 +254,4 @@ jobs:
         with:
           tag: ${{ env.NPM_VERSION }}
           commit_sha: ${{ github.sha }}
-          message: Workflow run ${{github.server_url}}/${{github.repository}}/actions/runs/${{ github.run_id}} 
+          message: Workflow run ${{github.server_url}}/${{github.repository}}/actions/runs/${{ github.run_id}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,6 +59,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    needs: [ build ]
     steps:
       - uses: actions/checkout@v2
 
@@ -93,6 +94,7 @@ jobs:
 
   build-documentation:
     runs-on: ubuntu-latest
+    needs: [ build, test ]
     steps:
       - uses: actions/checkout@v2
 

--- a/jest.jsdom.config.js
+++ b/jest.jsdom.config.js
@@ -10,5 +10,6 @@ export default {
     reporters: ["default", ["jest-junit", { outputName: "junit-jsdom.xml" }]],
     moduleNameMapper: {
       '^(\\.{1,2}/.*)\\.js$': '$1',
-    }
+    },
+    testTimeout: 30000
   };

--- a/jest.node.config.js
+++ b/jest.node.config.js
@@ -10,5 +10,6 @@ export default {
     reporters: ["default", ["jest-junit", { outputName: "junit-node.xml" }]],
     moduleNameMapper: {
       '^(\\.{1,2}/.*)\\.js$': '$1',
-    }
+    },
+    testTimeout: 30000
   };


### PR DESCRIPTION
- separate the build workflow step into a step that builds the npm artifact and another step that builds the documentation artifact
- separate publish documentation into it's own step
- increase the default test timeout from 5 seconds to 30 seconds