### PR TITLE
Rename API name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ export interface IEntriesClient {
                 The value should be a standard language tag.
      * @return Moves and/or renames an entry successfully.
      */
-    moveOrRenameDocument(args: { repoId: string, entryId: number, request?: PatchEntryRequest | undefined, autoRename?: boolean | undefined, culture?: string | null | undefined }): Promise<Entry>;
+    moveOrRenameEntry(args: { repoId: string, entryId: number, request?: PatchEntryRequest | undefined, autoRename?: boolean | undefined, culture?: string | null | undefined }): Promise<Entry>;
 
     /**
      * Returns a single entry object using the entry path. Optional query parameter: fallbackToClosestAncestor. Use the fallbackToClosestAncestor query parameter to return the closest existing ancestor if the initial entry path is not found.
@@ -890,7 +890,7 @@ export class EntriesClient implements IEntriesClient {
                 The value should be a standard language tag.
      * @return Moves and/or renames an entry successfully.
      */
-    moveOrRenameDocument(args: { repoId: string, entryId: number, request?: PatchEntryRequest | undefined, autoRename?: boolean | undefined, culture?: string | null | undefined }): Promise<Entry> {
+    moveOrRenameEntry(args: { repoId: string, entryId: number, request?: PatchEntryRequest | undefined, autoRename?: boolean | undefined, culture?: string | null | undefined }): Promise<Entry> {
         let { repoId, entryId, request, autoRename, culture } = args;
         let url_ = this.baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}?";
         if (repoId === undefined || repoId === null)
@@ -919,11 +919,11 @@ export class EntriesClient implements IEntriesClient {
         };
 
         return this.http.fetch(url_, options_).then((_response: Response) => {
-            return this.processMoveOrRenameDocument(_response);
+            return this.processMoveOrRenameEntry(_response);
         });
     }
 
-    protected processMoveOrRenameDocument(response: Response): Promise<Entry> {
+    protected processMoveOrRenameEntry(response: Response): Promise<Entry> {
         const status = response.status;
         let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
         if (status === 200) {

--- a/swagger.json
+++ b/swagger.json
@@ -1126,7 +1126,7 @@
         ],
         "summary": "Moves and/or renames an entry. Move and/or rename an entry by passing in the new parent folder ID or name in the JSON body. Optional parameter: autoRename (default false). If an entry already exists with the given name, the entry will be automatically renamed.",
         "description": "- Moves and/or renames an entry.\n- Move and/or rename an entry by passing in the new parent folder ID or name in the JSON body.\n- Optional parameter: autoRename (default false). If an entry already exists with the given name, the entry will be automatically renamed.",
-        "operationId": "MoveOrRenameDocument",
+        "operationId": "MoveOrRenameEntry",
         "parameters": [
           {
             "name": "repoId",

--- a/test/Entries/MoveEntries.test.ts
+++ b/test/Entries/MoveEntries.test.ts
@@ -26,7 +26,7 @@ describe('Move Entries Integration Tests', () => {
     request.parentId = parentFolder.id;
     request.name = 'RepositoryApiClientIntegrationTest JS MovedFolder';
 
-    let movedEntry: Entry = await _RepositoryApiClient.entriesClient.moveOrRenameDocument({
+    let movedEntry: Entry = await _RepositoryApiClient.entriesClient.moveOrRenameEntry({
       repoId,
       entryId: childFolder.id ?? -1,
       request,


### PR DESCRIPTION
The `moveOrRenameDocument` API can also be applied to other types of entries, not just `Document`. So in this PR, we changed its name to `moveOrRenameEntry` to better reflect its capability.