### PR TITLE
Fix test assertions

### DIFF
--- a/test/AccessTokens/AccessToken.test.ts
+++ b/test/AccessTokens/AccessToken.test.ts
@@ -11,7 +11,7 @@ describe('Access Token Integration Tests', () => {
     });
     let expireTime: Date | undefined = refreshResponse.value;
     let expireTimeInStr = expireTime?.toString() ?? '';
-    expect(expireTime).not.toBeNull;
+    expect(expireTime).not.toBeNull();
     expect(currentTime < expireTimeInStr).toBe(true);
   });
   test('Invalidate Server Session', async () => {

--- a/test/Entries/CreateCopyEntryCopyEntry.test.ts
+++ b/test/Entries/CreateCopyEntryCopyEntry.test.ts
@@ -43,7 +43,7 @@ describe('Create Copy Entry Test', () => {
       request,
       autoRename: true,
     });
-    expect(targetEntry).not.toBeNull;
+    expect(targetEntry).not.toBeNull();
     createdEntries.push(targetEntry);
     expect(targetEntry.parentId).toBe(testFolder.id);
     expect(targetEntry.entryType).toBe(EntryType.Folder);
@@ -75,7 +75,7 @@ describe('Create Copy Entry Test', () => {
       entryId: testFolder.id ?? -1,
       request: deleteEntryRequest,
     });
-    expect(deletionResult.token).not.toBeNull;
+    expect(deletionResult.token).not.toBeNull();
     expect(deletionResult.token).not.toBe('');
   });
 });

--- a/test/Entries/DeleteEntry.test.ts
+++ b/test/Entries/DeleteEntry.test.ts
@@ -14,7 +14,7 @@ describe('Delete Entries Integration Tests', () => {
       request: body,
     });
     let token: string = result.token ?? '';
-    expect(token).not.toBeNull;
+    expect(token).not.toBeNull();
     expect(token).not.toBe('');
   });
 });

--- a/test/Entries/GetDynamicFields.test.ts
+++ b/test/Entries/GetDynamicFields.test.ts
@@ -12,7 +12,7 @@ describe('Dynamic Fields Integration Tests', () => {
     if (!templateDefinitions) {
       throw new Error('templateDefinitions is undefined');
     }
-    expect(templateDefinitions).not.toBeNull;
+    expect(templateDefinitions).not.toBeNull();
     expect(templateDefinitions?.length).toBeGreaterThan(0);
     let request = new GetDynamicFieldLogicValueRequest();
     request.templateId = templateDefinitions[0].id;
@@ -21,6 +21,6 @@ describe('Dynamic Fields Integration Tests', () => {
       entryId,
       request,
     });
-    expect(dynamicFieldValueResponse).not.toBeNull;
+    expect(dynamicFieldValueResponse).not.toBeNull();
   });
 });

--- a/test/Entries/GetEntries.test.ts
+++ b/test/Entries/GetEntries.test.ts
@@ -43,10 +43,10 @@ describe('Get Entries Integration Tests', () => {
     expect(result?.entry.id).toBe(1);
     expect(result?.entry.fullPath).toBe(rootPath);
     expect(result?.entry.entryType).toBe('Folder');
-    expect(result?.ancestorEntry).toBeNull();
+    expect(result?.ancestorEntry).toBeUndefined();
   });
 
-  test('Get Entry By Full Path Return Ancestor Root Folder', async () => {
+  test.only('Get Entry By Full Path Return Ancestor Root Folder', async () => {
     let result: any = await _RepositoryApiClient.entriesClient.getEntryByPath({
       repoId,
       fullPath: nonExistingPath,
@@ -55,7 +55,7 @@ describe('Get Entries Integration Tests', () => {
     expect(result?.ancestorEntry.id).toBe(1);
     expect(result?.ancestorEntry.fullPath).toBe(rootPath);
     expect(result?.ancestorEntry.entryType).toBe('Folder');
-    expect(result?.entry).toBeNull();
+    expect(result?.entry).toBeUndefined();
   });
 
   // TODO use importDocument instead of hardcode entryId 3 https://github.com/Laserfiche/lf-repository-api-client-js/issues/53

--- a/test/Entries/GetEntries.test.ts
+++ b/test/Entries/GetEntries.test.ts
@@ -9,7 +9,7 @@ describe('Get Entries Integration Tests', () => {
 
   test('Get Entry Fields', async () => {
     let entryFieldResponse = await _RepositoryApiClient.entriesClient.getFieldValues({ repoId, entryId });
-    expect(entryFieldResponse?.value).not.toBeNull;
+    expect(entryFieldResponse?.value).not.toBeNull();
   });
   test('Get Entry Listing', async () => {
     let result: any = await _RepositoryApiClient.entriesClient.getEntryListing({
@@ -21,17 +21,17 @@ describe('Get Entries Integration Tests', () => {
 
   test('Get Entry Links', async () => {
     let result: any = await _RepositoryApiClient.entriesClient.getLinkValuesFromEntry({ repoId, entryId });
-    expect(result?.value).not.toBeNull;
+    expect(result?.value).not.toBeNull();
   });
 
   test('Get Entry Tags', async () => {
     let result: any = await _RepositoryApiClient.entriesClient.getTagsAssignedToEntry({ repoId, entryId });
-    expect(result?.value).not.toBeNull;
+    expect(result?.value).not.toBeNull();
   });
 
   test('Get Entry Return Root Folder', async () => {
     let result: any = await _RepositoryApiClient.entriesClient.getEntry({ repoId, entryId });
-    expect(result?.value).not.toBeNull;
+    expect(result?.value).not.toBeNull();
   });
 
   test('Get Entry By Full Path Return Root Folder', async () => {
@@ -43,7 +43,7 @@ describe('Get Entries Integration Tests', () => {
     expect(result?.entry.id).toBe(1);
     expect(result?.entry.fullPath).toBe(rootPath);
     expect(result?.entry.entryType).toBe('Folder');
-    expect(result?.ancestorEntry).toBeNull;
+    expect(result?.ancestorEntry).toBeNull();
   });
 
   test('Get Entry By Full Path Return Ancestor Root Folder', async () => {
@@ -55,7 +55,7 @@ describe('Get Entries Integration Tests', () => {
     expect(result?.ancestorEntry.id).toBe(1);
     expect(result?.ancestorEntry.fullPath).toBe(rootPath);
     expect(result?.ancestorEntry.entryType).toBe('Folder');
-    expect(result?.entry).toBeNull;
+    expect(result?.entry).toBeNull();
   });
 
   // TODO use importDocument instead of hardcode entryId 3 https://github.com/Laserfiche/lf-repository-api-client-js/issues/53

--- a/test/Entries/MoveEntries.test.ts
+++ b/test/Entries/MoveEntries.test.ts
@@ -32,7 +32,7 @@ describe('Move Entries Integration Tests', () => {
       request,
       autoRename: true,
     });
-    expect(movedEntry).not.toBeNull;
+    expect(movedEntry).not.toBeNull();
     expect(movedEntry.id).toBe(childFolder.id);
     expect(movedEntry.parentId).toBe(parentFolder.id);
     expect(movedEntry.name).toBe(request.name);

--- a/test/Entries/SetLinks.test.ts
+++ b/test/Entries/SetLinks.test.ts
@@ -41,7 +41,7 @@ describe('Set Entries Integration Tests', () => {
     if (!links) {
       throw new Error('links is undefined');
     }
-    expect(links).not.toBeNull;
+    expect(links).not.toBeNull();
     expect(request.length).toBe(links.length);
     expect(sourceEntry.id).toBe(links[0].sourceId);
     expect(targetEntry.id).toBe(links[0].targetId);

--- a/test/LinkDefinitions/GetLinkDefinitions.test.ts
+++ b/test/LinkDefinitions/GetLinkDefinitions.test.ts
@@ -14,9 +14,9 @@ describe('Link Definitions Integration Tests', () => {
       throw new Error('linkDefinitionsResponse.value');
     }
     let firstLinkDefinition = linkDefinitionsResponse.value[0];
-    expect(firstLinkDefinition).not.toBeNull;
+    expect(firstLinkDefinition).not.toBeNull();
   });
-  
+
 
   test('Get Link Definitions for each paging', async () => {
     let maxPageSize = 10;
@@ -38,7 +38,7 @@ describe('Link Definitions Integration Tests', () => {
     expect(entries).toBeGreaterThan(0);
     expect(pages).toBeGreaterThan(0);
   });
-  
+
 
   test('Get Link Definitions Simple Paging', async () => {
     let maxPageSize = 1;
@@ -62,5 +62,5 @@ describe('Link Definitions Integration Tests', () => {
     expect(response2.value.length).toBeLessThanOrEqual(maxPageSize);
   });
 
-  
+
 });

--- a/test/SimpleSearches/SimpleSearchTest.test.ts
+++ b/test/SimpleSearches/SimpleSearchTest.test.ts
@@ -12,7 +12,7 @@ describe('Simple Search Integration Tests', () => {
       repoId,
       request,
     });
-    expect(simpleSearchResponse.value).not.toBeNull;
+    expect(simpleSearchResponse.value).not.toBeNull();
   });
-  
+
 });

--- a/test/TagDefinitions/GetTagDefinitions.test.ts
+++ b/test/TagDefinitions/GetTagDefinitions.test.ts
@@ -7,7 +7,7 @@ describe('Tag Definitions Integration Tests', () => {
   test('Get Tag Definitions', async () => {
     let TagDefinitionsResponse: ODataValueContextOfIListOfWTagInfo =
       await _RepositoryApiClient.tagDefinitionsClient.getTagDefinitions({ repoId });
-    expect(TagDefinitionsResponse.value).not.toBeNull;
+    expect(TagDefinitionsResponse.value).not.toBeNull();
   });
 
   test('Get Tag Definitions for each paging', async () => {
@@ -56,12 +56,12 @@ describe('Tag Definitions Integration Tests', () => {
       throw new Error('TagDefinitionsResponse is undefined');
     }
     let firstTagDefinitionsResponse = TagDefinitionsResponse[0];
-    expect(allTagDefinitionsResponse.value).not.toBeNull;
+    expect(allTagDefinitionsResponse.value).not.toBeNull();
     let tagDefinition: WTagInfo = await _RepositoryApiClient.tagDefinitionsClient.getTagDefinitionById({
       repoId,
       tagId: firstTagDefinitionsResponse.id ?? -1,
     });
-    expect(tagDefinition).not.toBeNull;
+    expect(tagDefinition).not.toBeNull();
     expect(tagDefinition.id).toBe(firstTagDefinitionsResponse.id);
   });
 });

--- a/test/Tasks/Task.test.ts
+++ b/test/Tasks/Task.test.ts
@@ -17,7 +17,7 @@ describe('Task Integration Tests', () => {
       request: body,
     });
     let token: string | undefined = result.token;
-    expect(token).not.toBeNull;
+    expect(token).not.toBeNull();
     expect(token).not.toBe('');
     try {
       await new Promise((r) => setTimeout(r, 5000));
@@ -39,14 +39,14 @@ describe('Task Integration Tests', () => {
       request: body,
     });
     let token: string | undefined = result.token;
-    expect(token).not.toBeNull;
+    expect(token).not.toBeNull();
     expect(token).not.toBe('');
     await new Promise((r) => setTimeout(r, 5000));
     let operationProgress = await _RepositoryApiClient.tasksClient.getOperationStatusAndProgress({
       repoId,
       operationToken: token ?? '',
     });
-    expect(operationProgress).not.toBeNull;
+    expect(operationProgress).not.toBeNull();
     expect(operationProgress.status).toBe(OperationStatus.Completed);
     expect(operationProgress.percentComplete).toBe(100);
   });

--- a/test/TemplateDefinitions/GetTemplateDefinitions.test.ts
+++ b/test/TemplateDefinitions/GetTemplateDefinitions.test.ts
@@ -15,7 +15,7 @@ describe('Template Definitions Integration Tests', () => {
       throw new Error('templateDefinitionResponse.value');
     }
     let firstTemplateDefinition = templateDefinitionResponse.value[0];
-    expect(firstTemplateDefinition).not.toBeNull;
+    expect(firstTemplateDefinition).not.toBeNull();
     let result: ODataValueContextOfIListOfWTemplateInfo =
       await _RepositoryApiClient.templateDefinitionsClient.getTemplateDefinitions({
         repoId,
@@ -25,7 +25,7 @@ describe('Template Definitions Integration Tests', () => {
       throw new Error('result.value is undefined');
     }
     let templateInfo: WTemplateInfo = result.value[0];
-    expect(result).not.toBeNull;
+    expect(result).not.toBeNull();
     expect(result.value.length).toBe(1);
     expect(templateInfo.id).toBe(firstTemplateDefinition.id);
   });
@@ -36,14 +36,14 @@ describe('Template Definitions Integration Tests', () => {
       throw new Error('templateDefinitionResponse.value');
     }
     let firstTemplateDefinition = templateDefinitionResponse.value[0];
-    expect(firstTemplateDefinition).not.toBeNull;
+    expect(firstTemplateDefinition).not.toBeNull();
     let result: ODataValueContextOfIListOfTemplateFieldInfo =
       await _RepositoryApiClient.templateDefinitionsClient.getTemplateFieldDefinitions({
         repoId,
         templateId: firstTemplateDefinition.id ?? -1,
       });
     let templateDefinitions = result.value;
-    expect(templateDefinitions).not.toBeNull;
+    expect(templateDefinitions).not.toBeNull();
     expect(templateDefinitions?.length).toBe(firstTemplateDefinition.fieldCount);
   });
 
@@ -97,14 +97,14 @@ describe('Template Definitions Integration Tests', () => {
       throw new Error('templateDefinitionResponse.value');
     }
     let firstTemplateDefinition = templateDefinitionResponse.value[0];
-    expect(firstTemplateDefinition).not.toBeNull;
+    expect(firstTemplateDefinition).not.toBeNull();
     let result: ODataValueContextOfIListOfTemplateFieldInfo =
       await _RepositoryApiClient.templateDefinitionsClient.getTemplateFieldDefinitionsByTemplateName({
         repoId,
         templateName: firstTemplateDefinition.name ?? '',
       });
     let templateDefinitions = result.value;
-    expect(templateDefinitions).not.toBeNull;
+    expect(templateDefinitions).not.toBeNull();
     expect(templateDefinitions?.length).toBe(firstTemplateDefinition.fieldCount);
   });
 
@@ -137,12 +137,12 @@ describe('Template Definitions Integration Tests', () => {
       throw new Error('templateDefinitionResponse.value');
     }
     let firstTemplateDefinition = templateDefinitionResponse.value[0];
-    expect(firstTemplateDefinition).not.toBeNull;
+    expect(firstTemplateDefinition).not.toBeNull();
     let result = await _RepositoryApiClient.templateDefinitionsClient.getTemplateDefinitionById({
       repoId,
       templateId: firstTemplateDefinition.id ?? -1,
     });
-    expect(result).not.toBeNull;
+    expect(result).not.toBeNull();
     expect(result.id).toBe(firstTemplateDefinition.id);
   });
 


### PR DESCRIPTION
Fix test assertions that don't add a bracket to the function. For example, a test case like this will only fail at the third `expect` because there is a bracket on that function
```
  test.only('test', () => {
    expect(undefined).toBeDefined;
    expect("hi").toBeNull;
    expect('hi').toBeNull();
  });
```