### PR TITLE
Implement a helper function to makes it easier to use large file import apis

### DIFF
--- a/src/ClientBase.ts
+++ b/src/ClientBase.ts
@@ -580,7 +580,10 @@ export class EntriesClient extends generated.EntriesClient implements IEntriesCl
     }
   }
 
-  private prepareRequestForImportUploadedPartsApi(uploadId: string, eTags: string[], name?: string, autoRename?: boolean, pdfOptions?: generated.PdfImportOptions, importAsElectronicDocument?: boolean, metadata?: generated.ImportAsyncMetadata, volumeName?: string) {
+  /**
+   * Prepares and returns the request body for calling the ImportUploadedParts API.
+   */
+  private prepareRequestForImportUploadedPartsApi(uploadId: string, eTags: string[], name?: string, autoRename?: boolean, pdfOptions?: generated.PdfImportOptions, importAsElectronicDocument?: boolean, metadata?: generated.ImportAsyncMetadata, volumeName?: string): generated.StartImportUploadedPartsRequest {
     var parameters ={
       uploadId: uploadId,
       partETags: eTags,
@@ -594,6 +597,10 @@ export class EntriesClient extends generated.EntriesClient implements IEntriesCl
     return generated.StartImportUploadedPartsRequest.fromJS(parameters);
   }
 
+  /**
+   * Takes a file handler and a set of URLs. Then splits the file from the handler's current position, and writes the file parts to the given URLs.
+   * @returns The eTags of the parts written.
+   */
   private async writeFileParts(file: fsPromise.FileHandle, partSizeInMB: number, urls?: string[]): Promise<string[]> {
     if (urls) {
       let eTags = new Array<string>(urls?.length);
@@ -608,6 +615,10 @@ export class EntriesClient extends generated.EntriesClient implements IEntriesCl
     throw new Error("Writing file part failed.");
   }
 
+  /**
+   * Takes a file handler and a single URL, and writes a single file part to the given URL. The size of the part is determiend by the partSizeInMB parameter.
+   * @returns The eTag of the part written.
+   */
   private async writeFilePart(file: fsPromise.FileHandle, partSizeInMB: number, url: string): Promise<string> {
     const bufferSizeInBytes = partSizeInMB * 1024 * 1024;
     var buffer = new Uint8Array(bufferSizeInBytes);
@@ -629,6 +640,10 @@ export class EntriesClient extends generated.EntriesClient implements IEntriesCl
     throw new Error("No ETag.");
   }
 
+
+  /**
+   * Prepares and returns the request body for calling the CreateMultipartUploadUrls API.
+   */
   private prepareRequestForCreateMultipartUploadUrlsApi(iterationIndex: number, numberOfParts: number, numberOfUrlsRequestedInEachCall: number, fileName: string, mimeType: string, uploadId? : string | null): generated.CreateMultipartUploadUrlsRequest {
     var parameters = (iterationIndex == 0) ? {
       startingPartNumber: 1,
@@ -643,6 +658,9 @@ export class EntriesClient extends generated.EntriesClient implements IEntriesCl
     return generated.CreateMultipartUploadUrlsRequest.fromJS(parameters);
   }
 
+  /**
+   * Takes the file size as input and determies the number of parts and the part size (in MB). 
+   */
   private computeSplitInfo(fileSizeInBytes: number): [number, number] {
     const maxFileSizeInGB = 64;
 

--- a/src/ClientBase.ts
+++ b/src/ClientBase.ts
@@ -548,7 +548,7 @@ export class EntriesClient extends generated.EntriesClient implements IEntriesCl
       // Iteratively request URLs and write file chunks into the URLs.
       for (let i = 0; i < iterations; i++) {
         // Step 1: Request a batch of URLs by calling the CreateMultipartUploadUrls API.
-        var request = this.prepareRequestForCreateMultipartUploadUrlsApi(i, numberOfParts, maxUrlsRequestedInEachIteration, args.file.fileName, args.mimeType, uploadId);
+        var request = this.prepareRequestForCreateMultipartUploadUrlsApi(i, numberOfParts, maxUrlsRequestedInEachIteration, this.getFileName(args.file.fileName), args.mimeType, uploadId);
         let response = await this.createMultipartUploadUrls({
           repositoryId: args.repositoryId,
           request: request
@@ -580,6 +580,19 @@ export class EntriesClient extends generated.EntriesClient implements IEntriesCl
     }
   }
 
+  /**
+   * Returns the file name of a given file path.
+   * @param filePath The path to a file.
+   * @returns The file name.
+   */
+  private getFileName(filePath: string): string {
+    let fileName = filePath;
+    var index = filePath.lastIndexOf('/');
+    if (index >= 0) {
+      fileName = filePath.substring(index + 1);
+    }
+    return fileName;
+  }
   /**
    * Prepares and returns the request body for calling the ImportUploadedParts API.
    */

--- a/src/ClientBase.ts
+++ b/src/ClientBase.ts
@@ -329,14 +329,26 @@ export class AttributesClient extends generated.AttributesClient implements IAtt
 }
 
 export interface IEntriesClient {
-  startImport(args: {
-    fileName: string;
-    fileSizeInBytes: number;
-    mimeType: string;
+  /**
+   * Starts an asynchronous import operation to import a document.
+   * If successful, it returns a taskId which can be used to check the status of the import operation or retrieve the import result, otherwise, it returns an error.
+   * Required OAuth scope: repository.Write
+   * @param args.repositoryId The requested repository ID.
+   * @param args.entryId The entry ID of the folder that the document will be created in.
+   * @param args.culture (optional) An optional query parameter used to indicate the locale that should be used. The value should be a standard language tag. This may be used when setting field values with tokens.
+   * @param args.file The file to be imported as a new document. 
+   * @param args.fileSizeInBytes The length, in bytes, of the file to be imported as a new document. 
+   * @param args.mimeType The mime-type of the file to be imported as a new document. 
+   * @param args.request The body of the import request.
+   * @return A long operation task id.
+  */
+  startImportEntry(args: {
     repositoryId: string;
     entryId: number;
     culture?: string | null | undefined;
     file: generated.FileParameter;
+    fileSizeInBytes: number;
+    mimeType: string;
     request: generated.ImportEntryRequest;
   }): Promise<generated.StartTaskResponse>;
   /**
@@ -499,26 +511,26 @@ export interface IEntriesClient {
 }
 export class EntriesClient extends generated.EntriesClient implements IEntriesClient {
   /**
-   * 
-   * @param args.fileName ------------------------------------------
-   * @param args.fileSizeInBytes ------------------------------------------
-   * @param args.mimeType ------------------------------------------
+   * Starts an asynchronous import operation to import a document.
+   * If successful, it returns a taskId which can be used to check the status of the import operation or retrieve the import result, otherwise, it returns an error.
+   * Required OAuth scope: repository.Write
    * @param args.repositoryId The requested repository ID.
    * @param args.entryId The entry ID of the folder that the document will be created in.
    * @param args.culture (optional) An optional query parameter used to indicate the locale that should be used. The value should be a standard language tag. This may be used when setting field values with tokens.
-   * @param args.file (optional) 
-   * @param args.request (optional) 
-   * @return -------------------------------------
-   */
-  async startImport(args: { 
-    fileName: string;
+   * @param args.file The file to be imported as a new document. 
+   * @param args.fileSizeInBytes The length, in bytes, of the file to be imported as a new document. 
+   * @param args.mimeType The mime-type of the file to be imported as a new document. 
+   * @param args.request The body of the import request.
+   * @return A long operation task id.
+  */
+  async startImportEntry(args: { 
+    repositoryId: string;
+    entryId: number;
+    culture?: string | null | undefined;
+    file: generated.FileParameter;
     fileSizeInBytes: number;
-    mimeType: string; 
-    repositoryId: string; 
-    entryId: number; 
-    culture?: string | null | undefined; 
-    file: generated.FileParameter; 
-    request: generated.ImportEntryRequest; 
+    mimeType: string;
+    request: generated.ImportEntryRequest;
   }): Promise<generated.StartTaskResponse> {
     // Determine how many parts does the file have, and as a result how many URLs is needed. 
     const [numberOfParts, partSizeInMB] = this.computeSplitInfo(args.fileSizeInBytes);
@@ -536,7 +548,7 @@ export class EntriesClient extends generated.EntriesClient implements IEntriesCl
       // Iteratively request URLs and write file chunks into the URLs.
       for (let i = 0; i < iterations; i++) {
         // Step 1: Request a batch of URLs by calling the CreateMultipartUploadUrls API.
-        var request = this.prepareRequestForCreateMultipartUploadUrlsApi(i, numberOfParts, maxUrlsRequestedInEachIteration, args.fileName, args.mimeType, uploadId);
+        var request = this.prepareRequestForCreateMultipartUploadUrlsApi(i, numberOfParts, maxUrlsRequestedInEachIteration, args.file.fileName, args.mimeType, uploadId);
         let response = await this.createMultipartUploadUrls({
           repositoryId: args.repositoryId,
           request: request

--- a/src/ClientBase.ts
+++ b/src/ClientBase.ts
@@ -585,7 +585,7 @@ export class EntriesClient extends generated.EntriesClient implements IEntriesCl
    * @param filePath The path to a file.
    * @returns The file name.
    */
-  private getFileName(filePath: string): string {
+  getFileName(filePath: string): string {
     let fileName = filePath;
     var index = filePath.lastIndexOf('/');
     if (index >= 0) {
@@ -596,7 +596,7 @@ export class EntriesClient extends generated.EntriesClient implements IEntriesCl
   /**
    * Prepares and returns the request body for calling the ImportUploadedParts API.
    */
-  private prepareRequestForImportUploadedPartsApi(uploadId: string, eTags: string[], name?: string, autoRename?: boolean, pdfOptions?: generated.PdfImportOptions, importAsElectronicDocument?: boolean, metadata?: generated.ImportAsyncMetadata, volumeName?: string): generated.StartImportUploadedPartsRequest {
+  prepareRequestForImportUploadedPartsApi(uploadId: string, eTags: string[], name?: string, autoRename?: boolean, pdfOptions?: generated.PdfImportOptions, importAsElectronicDocument?: boolean, metadata?: generated.ImportAsyncMetadata, volumeName?: string): generated.StartImportUploadedPartsRequest {
     var parameters ={
       uploadId: uploadId,
       partETags: eTags,
@@ -614,7 +614,7 @@ export class EntriesClient extends generated.EntriesClient implements IEntriesCl
    * Takes a file handler and a set of URLs. Then splits the file from the handler's current position, and writes the file parts to the given URLs.
    * @returns The eTags of the parts written.
    */
-  private async writeFileParts(file: fsPromise.FileHandle, partSizeInMB: number, urls?: string[]): Promise<string[]> {
+  async writeFileParts(file: fsPromise.FileHandle, partSizeInMB: number, urls?: string[]): Promise<string[]> {
     if (urls) {
       let eTags = new Array<string>(urls?.length);
       for (let i = 0; i < urls.length; i++) {
@@ -632,7 +632,7 @@ export class EntriesClient extends generated.EntriesClient implements IEntriesCl
    * Takes a file handler and a single URL, and writes a single file part to the given URL. The size of the part is determiend by the partSizeInMB parameter.
    * @returns The eTag of the part written.
    */
-  private async writeFilePart(file: fsPromise.FileHandle, partSizeInMB: number, url: string): Promise<string> {
+  async writeFilePart(file: fsPromise.FileHandle, partSizeInMB: number, url: string): Promise<string> {
     const bufferSizeInBytes = partSizeInMB * 1024 * 1024;
     var buffer = new Uint8Array(bufferSizeInBytes);
     var readResult = await file.read(buffer, 0, bufferSizeInBytes);
@@ -657,7 +657,7 @@ export class EntriesClient extends generated.EntriesClient implements IEntriesCl
   /**
    * Prepares and returns the request body for calling the CreateMultipartUploadUrls API.
    */
-  private prepareRequestForCreateMultipartUploadUrlsApi(iterationIndex: number, numberOfParts: number, numberOfUrlsRequestedInEachCall: number, fileName: string, mimeType: string, uploadId? : string | null): generated.CreateMultipartUploadUrlsRequest {
+  prepareRequestForCreateMultipartUploadUrlsApi(iterationIndex: number, numberOfParts: number, numberOfUrlsRequestedInEachCall: number, fileName: string, mimeType: string, uploadId? : string | null): generated.CreateMultipartUploadUrlsRequest {
     var parameters = (iterationIndex == 0) ? {
       startingPartNumber: 1,
       numberOfParts: Math.min(numberOfParts, numberOfUrlsRequestedInEachCall),
@@ -674,7 +674,7 @@ export class EntriesClient extends generated.EntriesClient implements IEntriesCl
   /**
    * Takes the file size as input and determies the number of parts and the part size (in MB). 
    */
-  private computeSplitInfo(fileSizeInBytes: number): [number, number] {
+  computeSplitInfo(fileSizeInBytes: number): [number, number] {
     const maxFileSizeInGB = 64;
 
     if (fileSizeInBytes > maxFileSizeInGB * 1024 * 1024 * 1024) 

--- a/src/ClientBase.ts
+++ b/src/ClientBase.ts
@@ -537,7 +537,6 @@ export class EntriesClient extends generated.EntriesClient implements IEntriesCl
     var dataSource = null;
     try 
     {
-
       if (isBrowser()) {
         dataSource = args.file.data;
       } else {
@@ -576,14 +575,12 @@ export class EntriesClient extends generated.EntriesClient implements IEntriesCl
       });
   
       return generated.StartTaskResponse.fromJS(response);
-  
     } finally {
       if (dataSource && !isBrowser()) {
         dataSource.close();
       }
     }
   }
-
   /**
    * Returns the file name of a given file path.
    * @param filePath The path to a file.
@@ -613,7 +610,6 @@ export class EntriesClient extends generated.EntriesClient implements IEntriesCl
     };
     return generated.StartImportUploadedPartsRequest.fromJS(parameters);
   }
-
   /**
    * Takes a source for reading file data, and a set of URLs. 
    * Then reads data from the source, on a part-by-part basis, and and writes the file parts to the given URLs.
@@ -623,7 +619,6 @@ export class EntriesClient extends generated.EntriesClient implements IEntriesCl
     let partSizeInMB = 100;
     let eTags = new Array<string>(urls.length);
     var writtenParts = 0;
-
     var partNumber = 0;
     for (let i = 0; i < urls.length; i++) {
       partNumber++;
@@ -646,7 +641,9 @@ export class EntriesClient extends generated.EntriesClient implements IEntriesCl
     }
     return eTags.slice(0, writtenParts);
   }
-
+  /**
+   * Reads one part from the given file. This is used in non-browser mode.
+   */
   async readOnePartForNonBrowserMode(file: fsPromise.FileHandle, partSizeInMB: number): Promise<[Uint8Array, boolean]> {
     const bufferSizeInBytes = partSizeInMB * 1024 * 1024;
     var buffer = new Uint8Array(bufferSizeInBytes);
@@ -655,7 +652,9 @@ export class EntriesClient extends generated.EntriesClient implements IEntriesCl
     var partData = readResult.buffer.subarray(0, readResult.bytesRead);
     return [partData, endOfFileReached];
   }
-
+  /**
+   * Reads one part from the given blob. This is used in browser mode.
+   */
   async readOnePartForBrowserMode(blob: Blob, partSizeInMB: number, partNumber: number): Promise<[Uint8Array | null, boolean]> {
     const bufferSizeInBytes = partSizeInMB * 1024 * 1024;
     var offset = (partNumber - 1) *  bufferSizeInBytes;
@@ -680,7 +679,6 @@ export class EntriesClient extends generated.EntriesClient implements IEntriesCl
     }
     return [partData, endOfFileReached];
   }
-
     /**
    * Takes a file part and a single URL, and writes the part to the given URL.
    * @returns The eTag of the part written.
@@ -701,7 +699,6 @@ export class EntriesClient extends generated.EntriesClient implements IEntriesCl
     
     return eTag;
   }
-
   /**
    * Prepares and returns the request body for calling the CreateMultipartUploadUrls API.
    */
@@ -718,7 +715,6 @@ export class EntriesClient extends generated.EntriesClient implements IEntriesCl
     };
     return generated.CreateMultipartUploadUrlsRequest.fromJS(parameters);
   }
-
   /**
    * It will continue to make the same call to get a list of entry listings of a fixed size (i.e. maxpagesize) until it reaches the last page (i.e. when next link is null/undefined) or whenever the callback function returns false.
    * @param args.callback async callback function that will accept the current page results and return a boolean value to either continue or stop paging.

--- a/src/ClientBase.ts
+++ b/src/ClientBase.ts
@@ -330,15 +330,15 @@ export class AttributesClient extends generated.AttributesClient implements IAtt
 
 export interface IEntriesClient {
   /**
-   * Starts an asynchronous import operation to import a document.
-   * If successful, it returns a taskId which can be used to check the status of the import operation or retrieve the import result, otherwise, it returns an error.
+   * This is a helper for wrapping the CreateMultipartUploadURls and the ImportUploadedParts APIs. 
+   * If successful, it returns a taskId which can be used to check the status of the operation or retrieve its result, otherwise, it returns an error.
    * Required OAuth scope: repository.Write
    * @param args.repositoryId The requested repository ID.
    * @param args.entryId The entry ID of the folder that the document will be created in.
    * @param args.file The file to be imported as a new document. 
    * @param args.fileSizeInBytes The length, in bytes, of the file to be imported as a new document. 
    * @param args.mimeType The mime-type of the file to be imported as a new document. 
-   * @param args.request The body of the import request.
+   * @param args.request The body of the request.
    * @param args.culture (optional) An optional query parameter used to indicate the locale that should be used. The value should be a standard language tag. This may be used when setting field values with tokens.
    * @return A long operation task id.
   */
@@ -511,15 +511,15 @@ export interface IEntriesClient {
 }
 export class EntriesClient extends generated.EntriesClient implements IEntriesClient {
   /**
-   * Starts an asynchronous import operation to import a document.
-   * If successful, it returns a taskId which can be used to check the status of the import operation or retrieve the import result, otherwise, it returns an error.
+   * This is a helper for wrapping the CreateMultipartUploadURls and the ImportUploadedParts APIs. 
+   * If successful, it returns a taskId which can be used to check the status of the operation or retrieve its result, otherwise, it returns an error.
    * Required OAuth scope: repository.Write
    * @param args.repositoryId The requested repository ID.
    * @param args.entryId The entry ID of the folder that the document will be created in.
    * @param args.file The file to be imported as a new document. 
    * @param args.fileSizeInBytes The length, in bytes, of the file to be imported as a new document. 
    * @param args.mimeType The mime-type of the file to be imported as a new document. 
-   * @param args.request The body of the import request.
+   * @param args.request The body of the request.
    * @param args.culture (optional) An optional query parameter used to indicate the locale that should be used. The value should be a standard language tag. This may be used when setting field values with tokens.
    * @return A long operation task id.
   */

--- a/src/ClientBase.ts
+++ b/src/ClientBase.ts
@@ -520,20 +520,23 @@ export class EntriesClient extends generated.EntriesClient implements IEntriesCl
     file: generated.FileParameter; 
     request: generated.ImportEntryRequest; 
   }): Promise<generated.StartTaskResponse> {
+    // Determine how many parts does the file have, and as a result how many URLs is needed. 
     const [numberOfParts, partSizeInMB] = this.computeSplitInfo(args.fileSizeInBytes);
-    console.log (`Split information is computed: fileSizeInBytes ${args.fileSizeInBytes}, numberOfParts: ${numberOfParts}, PartSizeInMB: ${partSizeInMB}`);
-    const numberOfUrlsRequestedInEachCall = 5;
-    const numberOfIterations = Math.ceil(numberOfParts / numberOfUrlsRequestedInEachCall);
+    // The maximum number of URLs requested in each call to the CreateMultipartUploadUrls API.
+    const maxUrlsRequestedInEachIteration = 10;
+    const iterations = Math.ceil(numberOfParts / maxUrlsRequestedInEachIteration);
     
     var file = null;
-    var eTags = null;
+    var eTags = new Array<string>();
     let uploadId = null;
     try 
     {
       file = await fsPromise.open(args.file.fileName, 'r');
-      for (let i = 0; i < numberOfIterations; i++) {
-        console.log (`Requesting upload URL batch #${i+1}`);
-        var request = this.createRequestForIteration(i, numberOfParts, numberOfUrlsRequestedInEachCall, args.fileName, args.mimeType, uploadId);
+
+      // Iteratively request URLs and write file chunks into the URLs.
+      for (let i = 0; i < iterations; i++) {
+        // Step 1: Request a batch of URLs by calling the CreateMultipartUploadUrls API.
+        var request = this.prepareRequestForCreateMultipartUploadUrlsApi(i, numberOfParts, maxUrlsRequestedInEachIteration, args.fileName, args.mimeType, uploadId);
         let response = await this.createMultipartUploadUrls({
           repositoryId: args.repositoryId,
           request: request
@@ -541,36 +544,42 @@ export class EntriesClient extends generated.EntriesClient implements IEntriesCl
 
         if (i == 0) {
           uploadId = response.uploadId;
-          console.log(`Upload Id: ${response.uploadId}`);
         }
-
-        eTags = await this.writeFileParts(file, partSizeInMB, response.urls);
+        
+        // Step 2: Split the file and write the chunks to current batch of URLs.
+        var eTagsForThisIteration = await this.writeFileParts(file, partSizeInMB, response.urls);
+        eTags.push.apply(eTags, eTagsForThisIteration);
       }
+
+      // Step 3: File chunks are written, and eTags are ready. Call the ImportUploadedParts API.
+      var finalRequest = this.prepareRequestForImportUploadedPartsApi(uploadId!, eTags, args.request.name, args.request.autoRename, args.request.pdfOptions, args.request.importAsElectronicDocument, args.request.metadata, args.request.volumeName);
+      var response = await this.startImportUploadedParts({
+        repositoryId: args.repositoryId,
+        entryId: args.entryId,
+        request: finalRequest
+      });
+  
+      return generated.StartTaskResponse.fromJS(response);
+  
     } finally {
       if (file) {
         file.close();
       }
     }
+  }
 
+  private prepareRequestForImportUploadedPartsApi(uploadId: string, eTags: string[], name?: string, autoRename?: boolean, pdfOptions?: generated.PdfImportOptions, importAsElectronicDocument?: boolean, metadata?: generated.ImportAsyncMetadata, volumeName?: string) {
     var parameters ={
       uploadId: uploadId,
       partETags: eTags,
-      name: args.request.name,
-      autoRename: args.request.autoRename,
-      pdfOptions: args.request.pdfOptions,
-      importAsElectronicDocument: args.request.importAsElectronicDocument,
-      metadata: args.request.metadata,
-      volumeName: args.request.volumeName
+      name: name,
+      autoRename: autoRename,
+      pdfOptions: pdfOptions,
+      importAsElectronicDocument: importAsElectronicDocument,
+      metadata: metadata,
+      volumeName: volumeName
     };
-
-    var request2 =  generated.StartImportUploadedPartsRequest.fromJS(parameters);
-    var response = await this.startImportUploadedParts({
-      repositoryId: args.repositoryId,
-      entryId: args.entryId,
-      request: request2
-    });
-
-    return generated.StartTaskResponse.fromJS(response);
+    return generated.StartImportUploadedPartsRequest.fromJS(parameters);
   }
 
   private async writeFileParts(file: fsPromise.FileHandle, partSizeInMB: number, urls?: string[]): Promise<string[]> {
@@ -588,7 +597,7 @@ export class EntriesClient extends generated.EntriesClient implements IEntriesCl
   }
 
   private async writeFilePart(file: fsPromise.FileHandle, partSizeInMB: number, url: string): Promise<string> {
-    const bufferSizeInBytes = partSizeInMB * 1024;
+    const bufferSizeInBytes = partSizeInMB * 1024 * 1024;
     var buffer = new Uint8Array(bufferSizeInBytes);
     var readResult = await file.read(buffer, 0, bufferSizeInBytes);
     var content = readResult.buffer; 
@@ -608,7 +617,7 @@ export class EntriesClient extends generated.EntriesClient implements IEntriesCl
     throw new Error("No ETag.");
   }
 
-  private createRequestForIteration(iterationIndex: number, numberOfParts: number, numberOfUrlsRequestedInEachCall: number, fileName: string, mimeType: string, uploadId? : string | null): generated.CreateMultipartUploadUrlsRequest {
+  private prepareRequestForCreateMultipartUploadUrlsApi(iterationIndex: number, numberOfParts: number, numberOfUrlsRequestedInEachCall: number, fileName: string, mimeType: string, uploadId? : string | null): generated.CreateMultipartUploadUrlsRequest {
     var parameters = (iterationIndex == 0) ? {
       startingPartNumber: 1,
       numberOfParts: Math.min(numberOfParts, numberOfUrlsRequestedInEachCall),

--- a/src/ClientBase.ts
+++ b/src/ClientBase.ts
@@ -335,21 +335,21 @@ export interface IEntriesClient {
    * Required OAuth scope: repository.Write
    * @param args.repositoryId The requested repository ID.
    * @param args.entryId The entry ID of the folder that the document will be created in.
-   * @param args.culture (optional) An optional query parameter used to indicate the locale that should be used. The value should be a standard language tag. This may be used when setting field values with tokens.
    * @param args.file The file to be imported as a new document. 
    * @param args.fileSizeInBytes The length, in bytes, of the file to be imported as a new document. 
    * @param args.mimeType The mime-type of the file to be imported as a new document. 
    * @param args.request The body of the import request.
+   * @param args.culture (optional) An optional query parameter used to indicate the locale that should be used. The value should be a standard language tag. This may be used when setting field values with tokens.
    * @return A long operation task id.
   */
   startImportEntry(args: {
     repositoryId: string;
     entryId: number;
-    culture?: string | null | undefined;
     file: generated.FileParameter;
     fileSizeInBytes: number;
     mimeType: string;
     request: generated.ImportEntryRequest;
+    culture?: string | null | undefined;
   }): Promise<generated.StartTaskResponse>;
   /**
    * It will continue to make the same call to get a list of entry listings of a fixed size (i.e. maxpagesize) until it reaches the last page (i.e. when next link is null/undefined) or whenever the callback function returns false.
@@ -516,21 +516,21 @@ export class EntriesClient extends generated.EntriesClient implements IEntriesCl
    * Required OAuth scope: repository.Write
    * @param args.repositoryId The requested repository ID.
    * @param args.entryId The entry ID of the folder that the document will be created in.
-   * @param args.culture (optional) An optional query parameter used to indicate the locale that should be used. The value should be a standard language tag. This may be used when setting field values with tokens.
    * @param args.file The file to be imported as a new document. 
    * @param args.fileSizeInBytes The length, in bytes, of the file to be imported as a new document. 
    * @param args.mimeType The mime-type of the file to be imported as a new document. 
    * @param args.request The body of the import request.
+   * @param args.culture (optional) An optional query parameter used to indicate the locale that should be used. The value should be a standard language tag. This may be used when setting field values with tokens.
    * @return A long operation task id.
   */
   async startImportEntry(args: { 
     repositoryId: string;
     entryId: number;
-    culture?: string | null | undefined;
     file: generated.FileParameter;
     fileSizeInBytes: number;
     mimeType: string;
     request: generated.ImportEntryRequest;
+    culture?: string | null | undefined;
   }): Promise<generated.StartTaskResponse> {
     // Determine how many parts does the file have, and as a result how many URLs is needed. 
     const [numberOfParts, partSizeInMB] = this.computeSplitInfo(args.fileSizeInBytes);

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,65 +20,6 @@ import {
 } from '@laserfiche/lf-api-client-core';
 import { repositoryId } from '../test/TestHelper.js';
 import { url } from 'inspector';
-import operation to import a document.
-   * If successful, it returns a taskId which can be used to check the status of the import operation or retrieve the import result, otherwise, it returns an error.
-   * Required OAuth scope: repository.Write
-   * @param args.repositoryId The requested repository ID.
-   * @param args.entryId The entry ID of the folder that the document will be created in.
-   * @param args.file The file to be imported as a new document. 
-   * @param args.fileSizeInBytes The length, in bytes, of the file to be imported as a new document. 
-   * @param args.mimeType The mime-type of the file to be imported as a new document. 
-   * @param args.request The body of the import request.
-   * @param args.culture (optional) An optional query parameter used to indicate the locale that should be used. The value should be a standard language tag. This may be used when setting field values with tokens.
-   * @return A long operation task id.
-  */
-  startImportEntry(args: {
-    repositoryId: string;
-    entryId: number;
-    file: FileParameter;
-    fileSizeInBytes: number;
-    mimeType: string;
-    request: ImportEntryRequest;
-    culture?: string | null | undefined;
-  }): Promise<StartTaskResponse>;
-  /**
-   * It will continue to make the same call to get a list of entry listings of a fixed size (i.e. maxpagesize) until it reaches the last page (i.e. when next link is null/undefined) or whenever the callback function returns false.
-   * @param args.callback async callback function that will accept the current page results and return a boolean value to either continue or stop paging.
-   * @param args.repositoryId The requested repository ID.
-   * @param args.entryId The requested entry ID.
-   * @param args.groupByEntryType (optional) An optional query parameter used to indicate if the result should be grouped by entry type or not.
-   * @param args.fields (optional) Optional array of field names. Field values corresponding to the given field names will be returned for each entry.
-   * @param args.formatFieldValues (optional) Boolean for if field values should be formatted. Only applicable if Fields are specified.
-   * @param args.prefer (optional) An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
-   * @param args.culture (optional) An optional query parameter used to indicate the locale that should be used for formatting.
-          The value should be a standard language tag. The formatFieldValues query parameter must be set to true, otherwise
-          culture will not be used for formatting. 
-   * @param args.select (optional) Limits the properties returned in the result.
-   * @param args.orderby (optional) Specifies the order in which items are returned. The maximum number of expressions is 5.
-   * @param args.top (optional) Limits the number of items returned from a collection.
-import operation to import a document.
-   * If successful, it returns a taskId which can be used to check the status of the import operation or retrieve the import result, otherwise, it returns an error.
-   * Required OAuth scope: repository.Write
-   * @param args.repositoryId The requested repository ID.
-   * @param args.entryId The entry ID of the folder that the document will be created in.
-   * @param args.file The file to be imported as a new document. 
-   * @param args.fileSizeInBytes The length, in bytes, of the file to be imported as a new document. 
-   * @param args.mimeType The mime-type of the file to be imported as a new document. 
-   * @param args.request The body of the import request.
-   * @param args.culture (optional) An optional query parameter used to indicate the locale that should be used. The value should be a standard language tag. This may be used when setting field values with tokens.
-   * @return A long operation task id.
-  */
-  async startImportEntry(args: { 
-    repositoryId: string;
-    entryId: number;
-    file: FileParameter;
-    fileSizeInBytes: number;
-    mimeType: string;
-    request: ImportEntryRequest;
-    culture?: string | null | undefined;
-  }): Promise<StartTaskResponse> {
-    // Determine how many parts does the file have, and as a result how many URLs is needed. 
-    const [numberOfParts, partSizeInMB] = this.computeSplitInfo(args.fileSizeInBytes);
 
 export interface IAttributesClient {
 
@@ -1479,7 +1420,30 @@ export class EntriesClient implements IEntriesClient {
 
     
   /**
-   * Starts an asynchronous     // The maximum number of URLs requested in each call to the CreateMultipartUploadUrls API.
+   * This is a helper for wrapping the CreateMultipartUploadURls and the ImportUploadedParts APIs. 
+   * If successful, it returns a taskId which can be used to check the status of the operation or retrieve its result, otherwise, it returns an error.
+   * Required OAuth scope: repository.Write
+   * @param args.repositoryId The requested repository ID.
+   * @param args.entryId The entry ID of the folder that the document will be created in.
+   * @param args.file The file to be imported as a new document. 
+   * @param args.fileSizeInBytes The length, in bytes, of the file to be imported as a new document. 
+   * @param args.mimeType The mime-type of the file to be imported as a new document. 
+   * @param args.request The body of the request.
+   * @param args.culture (optional) An optional query parameter used to indicate the locale that should be used. The value should be a standard language tag. This may be used when setting field values with tokens.
+   * @return A long operation task id.
+  */
+  async startImportEntry(args: { 
+    repositoryId: string;
+    entryId: number;
+    file: FileParameter;
+    fileSizeInBytes: number;
+    mimeType: string;
+    request: ImportEntryRequest;
+    culture?: string | null | undefined;
+  }): Promise<StartTaskResponse> {
+    // Determine how many parts does the file have, and as a result how many URLs is needed. 
+    const [numberOfParts, partSizeInMB] = this.computeSplitInfo(args.fileSizeInBytes);
+    // The maximum number of URLs requested in each call to the CreateMultipartUploadUrls API.
     const maxUrlsRequestedInEachIteration = 10;
     const iterations = Math.ceil(numberOfParts / maxUrlsRequestedInEachIteration);
     
@@ -12487,7 +12451,43 @@ export interface IAttributesClient {
 
 export interface IEntriesClient {
   /**
-   * Starts an asynchronous    * @param args.skip (optional) Excludes the specified number of items of the queried collection from the result.
+   * This is a helper for wrapping the CreateMultipartUploadURls and the ImportUploadedParts APIs. 
+   * If successful, it returns a taskId which can be used to check the status of the operation or retrieve its result, otherwise, it returns an error.
+   * Required OAuth scope: repository.Write
+   * @param args.repositoryId The requested repository ID.
+   * @param args.entryId The entry ID of the folder that the document will be created in.
+   * @param args.file The file to be imported as a new document. 
+   * @param args.fileSizeInBytes The length, in bytes, of the file to be imported as a new document. 
+   * @param args.mimeType The mime-type of the file to be imported as a new document. 
+   * @param args.request The body of the request.
+   * @param args.culture (optional) An optional query parameter used to indicate the locale that should be used. The value should be a standard language tag. This may be used when setting field values with tokens.
+   * @return A long operation task id.
+  */
+  startImportEntry(args: {
+    repositoryId: string;
+    entryId: number;
+    file: FileParameter;
+    fileSizeInBytes: number;
+    mimeType: string;
+    request: ImportEntryRequest;
+    culture?: string | null | undefined;
+  }): Promise<StartTaskResponse>;
+  /**
+   * It will continue to make the same call to get a list of entry listings of a fixed size (i.e. maxpagesize) until it reaches the last page (i.e. when next link is null/undefined) or whenever the callback function returns false.
+   * @param args.callback async callback function that will accept the current page results and return a boolean value to either continue or stop paging.
+   * @param args.repositoryId The requested repository ID.
+   * @param args.entryId The requested entry ID.
+   * @param args.groupByEntryType (optional) An optional query parameter used to indicate if the result should be grouped by entry type or not.
+   * @param args.fields (optional) Optional array of field names. Field values corresponding to the given field names will be returned for each entry.
+   * @param args.formatFieldValues (optional) Boolean for if field values should be formatted. Only applicable if Fields are specified.
+   * @param args.prefer (optional) An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
+   * @param args.culture (optional) An optional query parameter used to indicate the locale that should be used for formatting.
+          The value should be a standard language tag. The formatFieldValues query parameter must be set to true, otherwise
+          culture will not be used for formatting. 
+   * @param args.select (optional) Limits the properties returned in the result.
+   * @param args.orderby (optional) Specifies the order in which items are returned. The maximum number of expressions is 5.
+   * @param args.top (optional) Limits the number of items returned from a collection.
+   * @param args.skip (optional) Excludes the specified number of items of the queried collection from the result.
    * @param args.count (optional) Indicates whether the total count of items within a collection are returned in the result.
    * @param args.maxPageSize (optional) the maximum page size or number of entry listings allowed per API response schema.
    */

--- a/src/index.ts
+++ b/src/index.ts
@@ -1525,7 +1525,10 @@ export class EntriesClient implements IEntriesClient {
     }
   }
 
-  private prepareRequestForImportUploadedPartsApi(uploadId: string, eTags: string[], name?: string, autoRename?: boolean, pdfOptions?: PdfImportOptions, importAsElectronicDocument?: boolean, metadata?: ImportAsyncMetadata, volumeName?: string) {
+  /**
+   * Prepares and returns the request body for calling the ImportUploadedParts API.
+   */
+  private prepareRequestForImportUploadedPartsApi(uploadId: string, eTags: string[], name?: string, autoRename?: boolean, pdfOptions?: PdfImportOptions, importAsElectronicDocument?: boolean, metadata?: ImportAsyncMetadata, volumeName?: string): StartImportUploadedPartsRequest {
     var parameters ={
       uploadId: uploadId,
       partETags: eTags,
@@ -1539,6 +1542,10 @@ export class EntriesClient implements IEntriesClient {
     return StartImportUploadedPartsRequest.fromJS(parameters);
   }
 
+  /**
+   * Takes a file handler and a set of URLs. Then splits the file from the handler's current position, and writes the file parts to the given URLs.
+   * @returns The eTags of the parts written.
+   */
   private async writeFileParts(file: fsPromise.FileHandle, partSizeInMB: number, urls?: string[]): Promise<string[]> {
     if (urls) {
       let eTags = new Array<string>(urls?.length);
@@ -1553,6 +1560,10 @@ export class EntriesClient implements IEntriesClient {
     throw new Error("Writing file part failed.");
   }
 
+  /**
+   * Takes a file handler and a single URL, and writes a single file part to the given URL. The size of the part is determiend by the partSizeInMB parameter.
+   * @returns The eTag of the part written.
+   */
   private async writeFilePart(file: fsPromise.FileHandle, partSizeInMB: number, url: string): Promise<string> {
     const bufferSizeInBytes = partSizeInMB * 1024 * 1024;
     var buffer = new Uint8Array(bufferSizeInBytes);
@@ -1574,6 +1585,9 @@ export class EntriesClient implements IEntriesClient {
     throw new Error("No ETag.");
   }
 
+  /**
+   * Prepares and returns the request body for calling the CreateMultipartUploadUrls API.
+   */
   private prepareRequestForCreateMultipartUploadUrlsApi(iterationIndex: number, numberOfParts: number, numberOfUrlsRequestedInEachCall: number, fileName: string, mimeType: string, uploadId? : string | null): CreateMultipartUploadUrlsRequest {
     var parameters = (iterationIndex == 0) ? {
       startingPartNumber: 1,
@@ -1588,6 +1602,9 @@ export class EntriesClient implements IEntriesClient {
     return CreateMultipartUploadUrlsRequest.fromJS(parameters);
   }
 
+  /**
+   * Takes the file size as input and determies the number of parts and the part size (in MB). 
+   */
   private computeSplitInfo(fileSizeInBytes: number): [number, number] {
     const maxFileSizeInGB = 64;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1457,7 +1457,7 @@ export class EntriesClient implements IEntriesClient {
       // Iteratively request URLs and write file chunks into the URLs.
       for (let i = 0; i < iterations; i++) {
         // Step 1: Request a batch of URLs by calling the CreateMultipartUploadUrls API.
-        var request = this.prepareRequestForCreateMultipartUploadUrlsApi(i, numberOfParts, maxUrlsRequestedInEachIteration, args.file.fileName, args.mimeType, uploadId);
+        var request = this.prepareRequestForCreateMultipartUploadUrlsApi(i, numberOfParts, maxUrlsRequestedInEachIteration, this.getFileName(args.file.fileName), args.mimeType, uploadId);
         let response = await this.createMultipartUploadUrls({
           repositoryId: args.repositoryId,
           request: request
@@ -1489,6 +1489,19 @@ export class EntriesClient implements IEntriesClient {
     }
   }
 
+  /**
+   * Returns the file name of a given file path.
+   * @param filePath The path to a file.
+   * @returns The file name.
+   */
+  private getFileName(filePath: string): string {
+    let fileName = filePath;
+    var index = filePath.lastIndexOf('/');
+    if (index >= 0) {
+      fileName = filePath.substring(index + 1);
+    }
+    return fileName;
+  }
   /**
    * Prepares and returns the request body for calling the ImportUploadedParts API.
    */

--- a/src/index.ts
+++ b/src/index.ts
@@ -1426,7 +1426,6 @@ export class EntriesClient implements IEntriesClient {
    * @param args.repositoryId The requested repository ID.
    * @param args.entryId The entry ID of the folder that the document will be created in.
    * @param args.file The file to be imported as a new document. 
-   * @param args.fileSizeInBytes The length, in bytes, of the file to be imported as a new document. 
    * @param args.mimeType The mime-type of the file to be imported as a new document. 
    * @param args.request The body of the request.
    * @param args.culture (optional) An optional query parameter used to indicate the locale that should be used. The value should be a standard language tag. This may be used when setting field values with tokens.
@@ -1436,17 +1435,13 @@ export class EntriesClient implements IEntriesClient {
     repositoryId: string;
     entryId: number;
     file: FileParameter;
-    fileSizeInBytes: number;
     mimeType: string;
     request: ImportEntryRequest;
     culture?: string | null | undefined;
   }): Promise<StartTaskResponse> {
-    // Determine how many parts does the file have, and as a result how many URLs is needed. 
-    const [numberOfParts, partSizeInMB] = this.computeSplitInfo(args.fileSizeInBytes);
     // The maximum number of URLs requested in each call to the CreateMultipartUploadUrls API.
-    const maxUrlsRequestedInEachIteration = 10;
-    const iterations = Math.ceil(numberOfParts / maxUrlsRequestedInEachIteration);
-    
+    const numberOfUrlsRequestedInEachCall = 10;
+    var thereAreMoreParts = true;   
     var file = null;
     var eTags = new Array<string>();
     let uploadId = null;
@@ -1454,22 +1449,26 @@ export class EntriesClient implements IEntriesClient {
     {
       file = await fsPromise.open(args.file.fileName, 'r');
 
+      let iteration = 0;
       // Iteratively request URLs and write file chunks into the URLs.
-      for (let i = 0; i < iterations; i++) {
+      while (thereAreMoreParts) {
+        iteration++;
         // Step 1: Request a batch of URLs by calling the CreateMultipartUploadUrls API.
-        var request = this.prepareRequestForCreateMultipartUploadUrlsApi(i, numberOfParts, maxUrlsRequestedInEachIteration, this.getFileName(args.file.fileName), args.mimeType, uploadId);
+        var request = this.prepareRequestForCreateMultipartUploadUrlsApi(iteration, numberOfUrlsRequestedInEachCall, this.getFileName(args.file.fileName), args.mimeType, uploadId);
         let response = await this.createMultipartUploadUrls({
           repositoryId: args.repositoryId,
           request: request
         });
 
-        if (i == 0) {
+        if (iteration == 1) {
           uploadId = response.uploadId;
         }
         
         // Step 2: Split the file and write the chunks to current batch of URLs.
-        var eTagsForThisIteration = await this.writeFileParts(file, partSizeInMB, response.urls);
+        var eTagsForThisIteration = await this.writeFileParts(file, response.urls!);
         eTags.push.apply(eTags, eTagsForThisIteration);
+
+        thereAreMoreParts = eTagsForThisIteration.length == numberOfUrlsRequestedInEachCall;
       }
 
       // Step 3: File chunks are written, and eTags are ready. Call the ImportUploadedParts API.
@@ -1523,76 +1522,67 @@ export class EntriesClient implements IEntriesClient {
    * Takes a file handler and a set of URLs. Then splits the file from the handler's current position, and writes the file parts to the given URLs.
    * @returns The eTags of the parts written.
    */
-  async writeFileParts(file: fsPromise.FileHandle, partSizeInMB: number, urls?: string[]): Promise<string[]> {
-    if (urls) {
-      let eTags = new Array<string>(urls?.length);
-      for (let i = 0; i < urls.length; i++) {
-        var url = urls[i];
-        var eTag = await this.writeFilePart(file, partSizeInMB, url);
-        eTags[i] = eTag;
+  async writeFileParts(file: fsPromise.FileHandle, urls: string[]): Promise<string[]> {
+    let eTags = new Array<string>(urls.length);
+    var writtenParts = 0;
+    for (let i = 0; i < urls.length; i++) {
+      var url = urls[i];
+      var [eTag, endOfFileReached] = await this.writeFilePart(file, url);
+      if (endOfFileReached) {
+        // There has been no more data to write.
+        break;
       }
-
-      return eTags;
+      writtenParts++;
+      eTags[i] = eTag;
     }
-    throw new Error("Writing file part failed.");
+
+    return eTags.slice(0, writtenParts);
   }
 
   /**
-   * Takes a file handler and a single URL, and writes a single file part to the given URL. The size of the part is determiend by the partSizeInMB parameter.
-   * @returns The eTag of the part written.
+   * Takes a file handler and a single URL, and writes one part of the file to the given URL.
+   * @returns The eTag of the part written, and a boolean flag which determines whether the end of file is reached.
    */
-  async writeFilePart(file: fsPromise.FileHandle, partSizeInMB: number, url: string): Promise<string> {
+  async writeFilePart(file: fsPromise.FileHandle, url: string): Promise<[string, boolean]> {
+    let partSizeInMB = 100;
     const bufferSizeInBytes = partSizeInMB * 1024 * 1024;
     var buffer = new Uint8Array(bufferSizeInBytes);
     var readResult = await file.read(buffer, 0, bufferSizeInBytes);
-    var content = readResult.buffer; 
-    const response = await fetch(url, {
-      method: 'PUT',
-      body: content,
-      headers: {'Content-Type': 'application/octet-stream'} });
+    var endOfFileReached = readResult.bytesRead == 0;
+    var content = readResult.buffer;
+    var eTag = "";
+    if (!endOfFileReached) {
+      const response = await fetch(url, {
+        method: 'PUT',
+        body: content,
+        headers: {'Content-Type': 'application/octet-stream'} });
+      
+      if (response.ok && response.body !== null && response.status == 200) {
+        eTag = response.headers.get("ETag")!;
+        if (eTag) {
+          eTag = eTag.substring(1, eTag.length - 1); // Remove heading and trailing double-quotation
+        }
+      } 
+    }
     
-    if (response.ok && response.body !== null && response.status == 200) {
-      var eTag = response.headers.get("ETag");
-      if (eTag) {
-        eTag = eTag.substring(1, eTag.length - 1); // Remove heading and trailing double-quotation
-        return eTag;
-      }
-    } 
-    
-    throw new Error("No ETag.");
+    return [eTag, endOfFileReached];
   }
 
   /**
    * Prepares and returns the request body for calling the CreateMultipartUploadUrls API.
    */
-  prepareRequestForCreateMultipartUploadUrlsApi(iterationIndex: number, numberOfParts: number, numberOfUrlsRequestedInEachCall: number, fileName: string, mimeType: string, uploadId? : string | null): CreateMultipartUploadUrlsRequest {
-    var parameters = (iterationIndex == 0) ? {
+  prepareRequestForCreateMultipartUploadUrlsApi(iteration: number, numberOfUrlsRequestedInEachCall: number, fileName: string, mimeType: string, uploadId? : string | null): CreateMultipartUploadUrlsRequest {
+    var parameters = (iteration == 1) ? {
       startingPartNumber: 1,
-      numberOfParts: Math.min(numberOfParts, numberOfUrlsRequestedInEachCall),
+      numberOfParts: numberOfUrlsRequestedInEachCall,
       fileName: fileName,
       mimeType: mimeType
     } : {
       uploadId: uploadId,
-      startingPartNumber: iterationIndex * numberOfUrlsRequestedInEachCall + 1,
-      numberOfParts: Math.min(numberOfParts - (iterationIndex * numberOfUrlsRequestedInEachCall), numberOfUrlsRequestedInEachCall),
+      startingPartNumber: (iteration - 1) * numberOfUrlsRequestedInEachCall + 1,
+      numberOfParts: numberOfUrlsRequestedInEachCall,
     };
     return CreateMultipartUploadUrlsRequest.fromJS(parameters);
-  }
-
-  /**
-   * Takes the file size as input and determies the number of parts and the part size (in MB). 
-   */
-  computeSplitInfo(fileSizeInBytes: number): [number, number] {
-    const maxFileSizeInGB = 64;
-
-    if (fileSizeInBytes > maxFileSizeInGB * 1024 * 1024 * 1024) 
-    {
-      throw new Error(`Maximum file size allowed is ${maxFileSizeInGB} GB.`);
-    }
-    const partSizeInMB = 100;
-    const numberOfParts = Math.ceil(fileSizeInBytes / (partSizeInMB * 1024 * 1024));
-
-    return [numberOfParts, partSizeInMB];
   }
 
   /**
@@ -12470,7 +12460,6 @@ export interface IEntriesClient {
    * @param args.repositoryId The requested repository ID.
    * @param args.entryId The entry ID of the folder that the document will be created in.
    * @param args.file The file to be imported as a new document. 
-   * @param args.fileSizeInBytes The length, in bytes, of the file to be imported as a new document. 
    * @param args.mimeType The mime-type of the file to be imported as a new document. 
    * @param args.request The body of the request.
    * @param args.culture (optional) An optional query parameter used to indicate the locale that should be used. The value should be a standard language tag. This may be used when setting field values with tokens.
@@ -12480,7 +12469,6 @@ export interface IEntriesClient {
     repositoryId: string;
     entryId: number;
     file: FileParameter;
-    fileSizeInBytes: number;
     mimeType: string;
     request: ImportEntryRequest;
     culture?: string | null | undefined;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1494,7 +1494,7 @@ export class EntriesClient implements IEntriesClient {
    * @param filePath The path to a file.
    * @returns The file name.
    */
-  private getFileName(filePath: string): string {
+  getFileName(filePath: string): string {
     let fileName = filePath;
     var index = filePath.lastIndexOf('/');
     if (index >= 0) {
@@ -1505,7 +1505,7 @@ export class EntriesClient implements IEntriesClient {
   /**
    * Prepares and returns the request body for calling the ImportUploadedParts API.
    */
-  private prepareRequestForImportUploadedPartsApi(uploadId: string, eTags: string[], name?: string, autoRename?: boolean, pdfOptions?: PdfImportOptions, importAsElectronicDocument?: boolean, metadata?: ImportAsyncMetadata, volumeName?: string): StartImportUploadedPartsRequest {
+  prepareRequestForImportUploadedPartsApi(uploadId: string, eTags: string[], name?: string, autoRename?: boolean, pdfOptions?: PdfImportOptions, importAsElectronicDocument?: boolean, metadata?: ImportAsyncMetadata, volumeName?: string): StartImportUploadedPartsRequest {
     var parameters ={
       uploadId: uploadId,
       partETags: eTags,
@@ -1523,7 +1523,7 @@ export class EntriesClient implements IEntriesClient {
    * Takes a file handler and a set of URLs. Then splits the file from the handler's current position, and writes the file parts to the given URLs.
    * @returns The eTags of the parts written.
    */
-  private async writeFileParts(file: fsPromise.FileHandle, partSizeInMB: number, urls?: string[]): Promise<string[]> {
+  async writeFileParts(file: fsPromise.FileHandle, partSizeInMB: number, urls?: string[]): Promise<string[]> {
     if (urls) {
       let eTags = new Array<string>(urls?.length);
       for (let i = 0; i < urls.length; i++) {
@@ -1541,7 +1541,7 @@ export class EntriesClient implements IEntriesClient {
    * Takes a file handler and a single URL, and writes a single file part to the given URL. The size of the part is determiend by the partSizeInMB parameter.
    * @returns The eTag of the part written.
    */
-  private async writeFilePart(file: fsPromise.FileHandle, partSizeInMB: number, url: string): Promise<string> {
+  async writeFilePart(file: fsPromise.FileHandle, partSizeInMB: number, url: string): Promise<string> {
     const bufferSizeInBytes = partSizeInMB * 1024 * 1024;
     var buffer = new Uint8Array(bufferSizeInBytes);
     var readResult = await file.read(buffer, 0, bufferSizeInBytes);
@@ -1565,7 +1565,7 @@ export class EntriesClient implements IEntriesClient {
   /**
    * Prepares and returns the request body for calling the CreateMultipartUploadUrls API.
    */
-  private prepareRequestForCreateMultipartUploadUrlsApi(iterationIndex: number, numberOfParts: number, numberOfUrlsRequestedInEachCall: number, fileName: string, mimeType: string, uploadId? : string | null): CreateMultipartUploadUrlsRequest {
+  prepareRequestForCreateMultipartUploadUrlsApi(iterationIndex: number, numberOfParts: number, numberOfUrlsRequestedInEachCall: number, fileName: string, mimeType: string, uploadId? : string | null): CreateMultipartUploadUrlsRequest {
     var parameters = (iterationIndex == 0) ? {
       startingPartNumber: 1,
       numberOfParts: Math.min(numberOfParts, numberOfUrlsRequestedInEachCall),
@@ -1582,7 +1582,7 @@ export class EntriesClient implements IEntriesClient {
   /**
    * Takes the file size as input and determies the number of parts and the part size (in MB). 
    */
-  private computeSplitInfo(fileSizeInBytes: number): [number, number] {
+  computeSplitInfo(fileSizeInBytes: number): [number, number] {
     const maxFileSizeInGB = 64;
 
     if (fileSizeInBytes > maxFileSizeInGB * 1024 * 1024 * 1024) 

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,21 +25,21 @@ import operation to import a document.
    * Required OAuth scope: repository.Write
    * @param args.repositoryId The requested repository ID.
    * @param args.entryId The entry ID of the folder that the document will be created in.
-   * @param args.culture (optional) An optional query parameter used to indicate the locale that should be used. The value should be a standard language tag. This may be used when setting field values with tokens.
    * @param args.file The file to be imported as a new document. 
    * @param args.fileSizeInBytes The length, in bytes, of the file to be imported as a new document. 
    * @param args.mimeType The mime-type of the file to be imported as a new document. 
    * @param args.request The body of the import request.
+   * @param args.culture (optional) An optional query parameter used to indicate the locale that should be used. The value should be a standard language tag. This may be used when setting field values with tokens.
    * @return A long operation task id.
   */
   startImportEntry(args: {
     repositoryId: string;
     entryId: number;
-    culture?: string | null | undefined;
     file: FileParameter;
     fileSizeInBytes: number;
     mimeType: string;
     request: ImportEntryRequest;
+    culture?: string | null | undefined;
   }): Promise<StartTaskResponse>;
   /**
    * It will continue to make the same call to get a list of entry listings of a fixed size (i.e. maxpagesize) until it reaches the last page (i.e. when next link is null/undefined) or whenever the callback function returns false.
@@ -61,21 +61,21 @@ import operation to import a document.
    * Required OAuth scope: repository.Write
    * @param args.repositoryId The requested repository ID.
    * @param args.entryId The entry ID of the folder that the document will be created in.
-   * @param args.culture (optional) An optional query parameter used to indicate the locale that should be used. The value should be a standard language tag. This may be used when setting field values with tokens.
    * @param args.file The file to be imported as a new document. 
    * @param args.fileSizeInBytes The length, in bytes, of the file to be imported as a new document. 
    * @param args.mimeType The mime-type of the file to be imported as a new document. 
    * @param args.request The body of the import request.
+   * @param args.culture (optional) An optional query parameter used to indicate the locale that should be used. The value should be a standard language tag. This may be used when setting field values with tokens.
    * @return A long operation task id.
   */
   async startImportEntry(args: { 
     repositoryId: string;
     entryId: number;
-    culture?: string | null | undefined;
     file: FileParameter;
     fileSizeInBytes: number;
     mimeType: string;
     request: ImportEntryRequest;
+    culture?: string | null | undefined;
   }): Promise<StartTaskResponse> {
     // Determine how many parts does the file have, and as a result how many URLs is needed. 
     const [numberOfParts, partSizeInMB] = this.computeSplitInfo(args.fileSizeInBytes);

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,65 @@ import {
 } from '@laserfiche/lf-api-client-core';
 import { repositoryId } from '../test/TestHelper.js';
 import { url } from 'inspector';
+import operation to import a document.
+   * If successful, it returns a taskId which can be used to check the status of the import operation or retrieve the import result, otherwise, it returns an error.
+   * Required OAuth scope: repository.Write
+   * @param args.repositoryId The requested repository ID.
+   * @param args.entryId The entry ID of the folder that the document will be created in.
+   * @param args.culture (optional) An optional query parameter used to indicate the locale that should be used. The value should be a standard language tag. This may be used when setting field values with tokens.
+   * @param args.file The file to be imported as a new document. 
+   * @param args.fileSizeInBytes The length, in bytes, of the file to be imported as a new document. 
+   * @param args.mimeType The mime-type of the file to be imported as a new document. 
+   * @param args.request The body of the import request.
+   * @return A long operation task id.
+  */
+  startImportEntry(args: {
+    repositoryId: string;
+    entryId: number;
+    culture?: string | null | undefined;
+    file: FileParameter;
+    fileSizeInBytes: number;
+    mimeType: string;
+    request: ImportEntryRequest;
+  }): Promise<StartTaskResponse>;
+  /**
+   * It will continue to make the same call to get a list of entry listings of a fixed size (i.e. maxpagesize) until it reaches the last page (i.e. when next link is null/undefined) or whenever the callback function returns false.
+   * @param args.callback async callback function that will accept the current page results and return a boolean value to either continue or stop paging.
+   * @param args.repositoryId The requested repository ID.
+   * @param args.entryId The requested entry ID.
+   * @param args.groupByEntryType (optional) An optional query parameter used to indicate if the result should be grouped by entry type or not.
+   * @param args.fields (optional) Optional array of field names. Field values corresponding to the given field names will be returned for each entry.
+   * @param args.formatFieldValues (optional) Boolean for if field values should be formatted. Only applicable if Fields are specified.
+   * @param args.prefer (optional) An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
+   * @param args.culture (optional) An optional query parameter used to indicate the locale that should be used for formatting.
+          The value should be a standard language tag. The formatFieldValues query parameter must be set to true, otherwise
+          culture will not be used for formatting. 
+   * @param args.select (optional) Limits the properties returned in the result.
+   * @param args.orderby (optional) Specifies the order in which items are returned. The maximum number of expressions is 5.
+   * @param args.top (optional) Limits the number of items returned from a collection.
+import operation to import a document.
+   * If successful, it returns a taskId which can be used to check the status of the import operation or retrieve the import result, otherwise, it returns an error.
+   * Required OAuth scope: repository.Write
+   * @param args.repositoryId The requested repository ID.
+   * @param args.entryId The entry ID of the folder that the document will be created in.
+   * @param args.culture (optional) An optional query parameter used to indicate the locale that should be used. The value should be a standard language tag. This may be used when setting field values with tokens.
+   * @param args.file The file to be imported as a new document. 
+   * @param args.fileSizeInBytes The length, in bytes, of the file to be imported as a new document. 
+   * @param args.mimeType The mime-type of the file to be imported as a new document. 
+   * @param args.request The body of the import request.
+   * @return A long operation task id.
+  */
+  async startImportEntry(args: { 
+    repositoryId: string;
+    entryId: number;
+    culture?: string | null | undefined;
+    file: FileParameter;
+    fileSizeInBytes: number;
+    mimeType: string;
+    request: ImportEntryRequest;
+  }): Promise<StartTaskResponse> {
+    // Determine how many parts does the file have, and as a result how many URLs is needed. 
+    const [numberOfParts, partSizeInMB] = this.computeSplitInfo(args.fileSizeInBytes);
 
 export interface IAttributesClient {
 
@@ -1420,30 +1479,7 @@ export class EntriesClient implements IEntriesClient {
 
     
   /**
-   * 
-   * @param args.fileName ------------------------------------------
-   * @param args.fileSizeInBytes ------------------------------------------
-   * @param args.mimeType ------------------------------------------
-   * @param args.repositoryId The requested repository ID.
-   * @param args.entryId The entry ID of the folder that the document will be created in.
-   * @param args.culture (optional) An optional query parameter used to indicate the locale that should be used. The value should be a standard language tag. This may be used when setting field values with tokens.
-   * @param args.file (optional) 
-   * @param args.request (optional) 
-   * @return -------------------------------------
-   */
-  async startImport(args: { 
-    fileName: string;
-    fileSizeInBytes: number;
-    mimeType: string; 
-    repositoryId: string; 
-    entryId: number; 
-    culture?: string | null | undefined; 
-    file: FileParameter; 
-    request: ImportEntryRequest; 
-  }): Promise<StartTaskResponse> {
-    // Determine how many parts does the file have, and as a result how many URLs is needed. 
-    const [numberOfParts, partSizeInMB] = this.computeSplitInfo(args.fileSizeInBytes);
-    // The maximum number of URLs requested in each call to the CreateMultipartUploadUrls API.
+   * Starts an asynchronous     // The maximum number of URLs requested in each call to the CreateMultipartUploadUrls API.
     const maxUrlsRequestedInEachIteration = 10;
     const iterations = Math.ceil(numberOfParts / maxUrlsRequestedInEachIteration);
     
@@ -1457,7 +1493,7 @@ export class EntriesClient implements IEntriesClient {
       // Iteratively request URLs and write file chunks into the URLs.
       for (let i = 0; i < iterations; i++) {
         // Step 1: Request a batch of URLs by calling the CreateMultipartUploadUrls API.
-        var request = this.prepareRequestForCreateMultipartUploadUrlsApi(i, numberOfParts, maxUrlsRequestedInEachIteration, args.fileName, args.mimeType, uploadId);
+        var request = this.prepareRequestForCreateMultipartUploadUrlsApi(i, numberOfParts, maxUrlsRequestedInEachIteration, args.file.fileName, args.mimeType, uploadId);
         let response = await this.createMultipartUploadUrls({
           repositoryId: args.repositoryId,
           request: request
@@ -12433,32 +12469,8 @@ export interface IAttributesClient {
 }
 
 export interface IEntriesClient {
-  startImport(args: {
-    fileName: string;
-    fileSizeInBytes: number;
-    mimeType: string;
-    repositoryId: string;
-    entryId: number;
-    culture?: string | null | undefined;
-    file: FileParameter;
-    request: ImportEntryRequest;
-  }): Promise<StartTaskResponse>;
   /**
-   * It will continue to make the same call to get a list of entry listings of a fixed size (i.e. maxpagesize) until it reaches the last page (i.e. when next link is null/undefined) or whenever the callback function returns false.
-   * @param args.callback async callback function that will accept the current page results and return a boolean value to either continue or stop paging.
-   * @param args.repositoryId The requested repository ID.
-   * @param args.entryId The requested entry ID.
-   * @param args.groupByEntryType (optional) An optional query parameter used to indicate if the result should be grouped by entry type or not.
-   * @param args.fields (optional) Optional array of field names. Field values corresponding to the given field names will be returned for each entry.
-   * @param args.formatFieldValues (optional) Boolean for if field values should be formatted. Only applicable if Fields are specified.
-   * @param args.prefer (optional) An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
-   * @param args.culture (optional) An optional query parameter used to indicate the locale that should be used for formatting.
-          The value should be a standard language tag. The formatFieldValues query parameter must be set to true, otherwise
-          culture will not be used for formatting. 
-   * @param args.select (optional) Limits the properties returned in the result.
-   * @param args.orderby (optional) Specifies the order in which items are returned. The maximum number of expressions is 5.
-   * @param args.top (optional) Limits the number of items returned from a collection.
-   * @param args.skip (optional) Excludes the specified number of items of the queried collection from the result.
+   * Starts an asynchronous    * @param args.skip (optional) Excludes the specified number of items of the queried collection from the result.
    * @param args.count (optional) Indicates whether the total count of items within a collection are returned in the result.
    * @param args.maxPageSize (optional) the maximum page size or number of entry listings allowed per API response schema.
    */

--- a/src/index.ts
+++ b/src/index.ts
@@ -1448,7 +1448,6 @@ export class EntriesClient implements IEntriesClient {
     var dataSource = null;
     try 
     {
-
       if (isBrowser()) {
         dataSource = args.file.data;
       } else {
@@ -1487,14 +1486,12 @@ export class EntriesClient implements IEntriesClient {
       });
   
       return StartTaskResponse.fromJS(response);
-  
     } finally {
       if (dataSource && !isBrowser()) {
         dataSource.close();
       }
     }
   }
-
   /**
    * Returns the file name of a given file path.
    * @param filePath The path to a file.
@@ -1524,7 +1521,6 @@ export class EntriesClient implements IEntriesClient {
     };
     return StartImportUploadedPartsRequest.fromJS(parameters);
   }
-
   /**
    * Takes a source for reading file data, and a set of URLs. 
    * Then reads data from the source, on a part-by-part basis, and and writes the file parts to the given URLs.
@@ -1534,7 +1530,6 @@ export class EntriesClient implements IEntriesClient {
     let partSizeInMB = 100;
     let eTags = new Array<string>(urls.length);
     var writtenParts = 0;
-
     var partNumber = 0;
     for (let i = 0; i < urls.length; i++) {
       partNumber++;
@@ -1557,7 +1552,9 @@ export class EntriesClient implements IEntriesClient {
     }
     return eTags.slice(0, writtenParts);
   }
-
+  /**
+   * Reads one part from the given file. This is used in non-browser mode.
+   */
   async readOnePartForNonBrowserMode(file: fsPromise.FileHandle, partSizeInMB: number): Promise<[Uint8Array, boolean]> {
     const bufferSizeInBytes = partSizeInMB * 1024 * 1024;
     var buffer = new Uint8Array(bufferSizeInBytes);
@@ -1566,7 +1563,9 @@ export class EntriesClient implements IEntriesClient {
     var partData = readResult.buffer.subarray(0, readResult.bytesRead);
     return [partData, endOfFileReached];
   }
-
+  /**
+   * Reads one part from the given blob. This is used in browser mode.
+   */
   async readOnePartForBrowserMode(blob: Blob, partSizeInMB: number, partNumber: number): Promise<[Uint8Array | null, boolean]> {
     const bufferSizeInBytes = partSizeInMB * 1024 * 1024;
     var offset = (partNumber - 1) *  bufferSizeInBytes;
@@ -1591,7 +1590,6 @@ export class EntriesClient implements IEntriesClient {
     }
     return [partData, endOfFileReached];
   }
-
     /**
    * Takes a file part and a single URL, and writes the part to the given URL.
    * @returns The eTag of the part written.
@@ -1612,7 +1610,6 @@ export class EntriesClient implements IEntriesClient {
     
     return eTag;
   }
-
   /**
    * Prepares and returns the request body for calling the CreateMultipartUploadUrls API.
    */
@@ -1629,7 +1626,6 @@ export class EntriesClient implements IEntriesClient {
     };
     return CreateMultipartUploadUrlsRequest.fromJS(parameters);
   }
-
   /**
    * It will continue to make the same call to get a list of entry listings of a fixed size (i.e. maxpagesize) until it reaches the last page (i.e. when next link is null/undefined) or whenever the callback function returns false.
    * @param args.callback async callback function that will accept the current page results and return a boolean value to either continue or stop paging.

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import {
 } from '@laserfiche/lf-api-client-core';
 import { repositoryId } from '../test/TestHelper.js';
 import { url } from 'inspector';
+import { isBrowser } from '@laserfiche/lf-js-utils/dist/utils/core-utils.js';
 
 export interface IAttributesClient {
 
@@ -1442,15 +1443,20 @@ export class EntriesClient implements IEntriesClient {
     // The maximum number of URLs requested in each call to the CreateMultipartUploadUrls API.
     const numberOfUrlsRequestedInEachCall = 10;
     var thereAreMoreParts = true;   
-    var file = null;
     var eTags = new Array<string>();
     let uploadId = null;
+    var dataSource = null;
     try 
     {
-      file = await fsPromise.open(args.file.fileName, 'r');
+
+      if (isBrowser()) {
+        dataSource = args.file.data;
+      } else {
+        dataSource = await fsPromise.open(args.file.fileName, 'r');
+      }
 
       let iteration = 0;
-      // Iteratively request URLs and write file chunks into the URLs.
+      // Iteratively request URLs and write file parts into the URLs.
       while (thereAreMoreParts) {
         iteration++;
         // Step 1: Request a batch of URLs by calling the CreateMultipartUploadUrls API.
@@ -1464,14 +1470,15 @@ export class EntriesClient implements IEntriesClient {
           uploadId = response.uploadId;
         }
         
-        // Step 2: Split the file and write the chunks to current batch of URLs.
-        var eTagsForThisIteration = await this.writeFileParts(file, response.urls!);
+        // Step 2: Split the file and write the parts to current batch of URLs.
+        var eTagsForThisIteration: any;
+        eTagsForThisIteration = await this.writeFileParts(dataSource!, response.urls!);
         eTags.push.apply(eTags, eTagsForThisIteration);
 
         thereAreMoreParts = eTagsForThisIteration.length == numberOfUrlsRequestedInEachCall;
       }
 
-      // Step 3: File chunks are written, and eTags are ready. Call the ImportUploadedParts API.
+      // Step 3: File parts are written, and eTags are ready. Call the ImportUploadedParts API.
       var finalRequest = this.prepareRequestForImportUploadedPartsApi(uploadId!, eTags, args.request.name, args.request.autoRename, args.request.pdfOptions, args.request.importAsElectronicDocument, args.request.metadata, args.request.volumeName);
       var response = await this.startImportUploadedParts({
         repositoryId: args.repositoryId,
@@ -1482,8 +1489,8 @@ export class EntriesClient implements IEntriesClient {
       return StartTaskResponse.fromJS(response);
   
     } finally {
-      if (file) {
-        file.close();
+      if (dataSource && !isBrowser()) {
+        dataSource.close();
       }
     }
   }
@@ -1519,42 +1526,81 @@ export class EntriesClient implements IEntriesClient {
   }
 
   /**
-   * Takes a file handler and a set of URLs. Then splits the file from the handler's current position, and writes the file parts to the given URLs.
+   * Takes a source for reading file data, and a set of URLs. 
+   * Then reads data from the source, on a part-by-part basis, and and writes the file parts to the given URLs.
    * @returns The eTags of the parts written.
    */
-  async writeFileParts(file: fsPromise.FileHandle, urls: string[]): Promise<string[]> {
+  async writeFileParts(source: any, urls: string[]): Promise<string[]> {
+    let partSizeInMB = 100;
     let eTags = new Array<string>(urls.length);
     var writtenParts = 0;
+
+    var partNumber = 0;
     for (let i = 0; i < urls.length; i++) {
+      partNumber++;
       var url = urls[i];
-      var [eTag, endOfFileReached] = await this.writeFilePart(file, url);
+      var partData: any;
+      var endOfFileReached: boolean;
+      if (isBrowser()) {
+        [partData, endOfFileReached] = await this.readOnePartForBrowserMode(source, partSizeInMB, partNumber);
+      } else {
+        [partData, endOfFileReached] = await this.readOnePartForNonBrowserMode(source, partSizeInMB);
+      }
+
       if (endOfFileReached) {
         // There has been no more data to write.
         break;
       }
+      var eTag = await this.writeFilePart(partData, url);
       writtenParts++;
       eTags[i] = eTag;
     }
-
     return eTags.slice(0, writtenParts);
   }
 
-  /**
-   * Takes a file handler and a single URL, and writes one part of the file to the given URL.
-   * @returns The eTag of the part written, and a boolean flag which determines whether the end of file is reached.
-   */
-  async writeFilePart(file: fsPromise.FileHandle, url: string): Promise<[string, boolean]> {
-    let partSizeInMB = 100;
+  async readOnePartForNonBrowserMode(file: fsPromise.FileHandle, partSizeInMB: number): Promise<[Uint8Array, boolean]> {
     const bufferSizeInBytes = partSizeInMB * 1024 * 1024;
     var buffer = new Uint8Array(bufferSizeInBytes);
     var readResult = await file.read(buffer, 0, bufferSizeInBytes);
     var endOfFileReached = readResult.bytesRead == 0;
-    var content = readResult.buffer;
+    var partData = readResult.buffer.subarray(0, readResult.bytesRead);
+    return [partData, endOfFileReached];
+  }
+
+  async readOnePartForBrowserMode(blob: Blob, partSizeInMB: number, partNumber: number): Promise<[Uint8Array | null, boolean]> {
+    const bufferSizeInBytes = partSizeInMB * 1024 * 1024;
+    var offset = (partNumber - 1) *  bufferSizeInBytes;
+    var partBlob = blob.slice(offset, offset + bufferSizeInBytes);
+    var endOfFileReached = false;
+    var partData = null;
+    var readerDone = false;
+    if (partBlob) {
+      const reader = new FileReader();
+      reader.addEventListener("loadend", (event) => {
+        var data = reader.result;
+        if (data instanceof ArrayBuffer) {
+          partData = new Uint8Array(data);
+          endOfFileReached = partData.byteLength == 0;
+        }
+        readerDone = true;
+      });
+      reader.readAsArrayBuffer(partBlob); 
+    }
+    while(!readerDone) {
+      await new Promise((r) => setTimeout(r, 5000));
+    }
+    return [partData, endOfFileReached];
+  }
+
+    /**
+   * Takes a file part and a single URL, and writes the part to the given URL.
+   * @returns The eTag of the part written.
+   */
+  async writeFilePart(part: Uint8Array, url: string): Promise<string> {
     var eTag = "";
-    if (!endOfFileReached) {
       const response = await fetch(url, {
         method: 'PUT',
-        body: content,
+        body: part,
         headers: {'Content-Type': 'application/octet-stream'} });
       
       if (response.ok && response.body !== null && response.status == 200) {
@@ -1563,9 +1609,8 @@ export class EntriesClient implements IEntriesClient {
           eTag = eTag.substring(1, eTag.length - 1); // Remove heading and trailing double-quotation
         }
       } 
-    }
     
-    return [eTag, endOfFileReached];
+    return eTag;
   }
 
   /**

--- a/test/Entries/LargeFileImport.test.ts
+++ b/test/Entries/LargeFileImport.test.ts
@@ -43,7 +43,6 @@ describe('Large File Import Integration Tests', () => {
             repositoryId,
             entryId: rootEntryId,
             file: edoc,
-            fileSizeInBytes: 63096545,
             mimeType: mimeType,
             request: request
         });
@@ -59,6 +58,7 @@ describe('Large File Import Integration Tests', () => {
     
         let taskProgress = response2.value![0];
         expect(taskProgress.status).toBe(TaskStatus.Completed);
+        
         expect(taskProgress.percentComplete).toBe(100);
         let createdEntryId = taskProgress.result?.entryId;
         var createdEntry = await _RepositoryApiClient.entriesClient.getEntry({repositoryId: repositoryId, entryId: createdEntryId!});

--- a/test/Entries/LargeFileImport.test.ts
+++ b/test/Entries/LargeFileImport.test.ts
@@ -1,0 +1,55 @@
+import { repositoryId } from '../TestHelper.js';
+import { _RepositoryApiClient } from '../CreateSession.js';
+import 'isomorphic-fetch';
+import { Blob as NodeBlob } from 'buffer';
+import { FileParameter, ImportEntryRequest, StartTaskResponse, TaskStatus } from '../../src/index.js';
+import { isBrowser } from '@laserfiche/lf-js-utils/dist/utils/core-utils.js';
+
+describe('Large File Import Integration Tests', () => {
+
+    test('Importing a 60MB file is successful', async () => {
+        let blob: any;
+        if (isBrowser()){
+            blob = new Blob([""], {
+                type: "application/json",
+              });
+        } else {
+            blob = new NodeBlob([""], {
+                type: "application/json",
+              });
+        }
+        const edoc : FileParameter = {
+            fileName: "test/Entries/sampleFiles/60MB.pdf",
+            data: blob
+          }
+          const request = new ImportEntryRequest();
+          request.autoRename = true;
+          request.name = "sample.pdf";
+          let response: StartTaskResponse = await _RepositoryApiClient.entriesClient.startImport({
+            fileName: "sample.pdf",
+            fileSizeInBytes: 63096545,
+            mimeType: "application/pdf",
+            repositoryId,
+            entryId: 1,
+            file: edoc,
+            request: request
+        });
+        await new Promise((r) => setTimeout(r, 30000));
+
+        var response2 = await _RepositoryApiClient.tasksClient.listTasks({
+            repositoryId,
+            taskIds: [response.taskId!],
+        });
+        
+        expect(response2).not.toBeNull();
+        expect(response2.value).not.toBeNull();
+        expect(response2.value!.length).toBeGreaterThan(0);
+    
+        let taskProgress = response2.value![0];
+        console.log(response2);
+        console.log(taskProgress.errors);
+        expect(taskProgress.status).toBe(TaskStatus.Completed);
+        expect(taskProgress.percentComplete).toBe(100);
+      });
+
+  });

--- a/test/Entries/LargeFileImport.test.ts
+++ b/test/Entries/LargeFileImport.test.ts
@@ -2,12 +2,12 @@ import { repositoryId } from '../TestHelper.js';
 import { _RepositoryApiClient } from '../CreateSession.js';
 import 'isomorphic-fetch';
 import { Blob as NodeBlob } from 'buffer';
-import { FileParameter, ImportEntryRequest, StartTaskResponse, TaskStatus } from '../../src/index.js';
+import { FileParameter, ImportAsyncMetadata, ImportEntryRequest, StartTaskResponse, TaskStatus } from '../../src/index.js';
 import { isBrowser } from '@laserfiche/lf-js-utils/dist/utils/core-utils.js';
 
 describe('Large File Import Integration Tests', () => {
 
-    test('Importing a 60MB file is successful', async () => {
+      test('Importing a 60MB file is successful', async () => {
         let blob: any;
         if (isBrowser()){
             blob = new Blob([""], {
@@ -22,19 +22,29 @@ describe('Large File Import Integration Tests', () => {
             fileName: "test/Entries/sampleFiles/60MB.pdf",
             data: blob
           }
+
+          var name = "sample.pdf";
+          var templateName = "Email";
+          var tagName = "TestTag";
+          var mimeType = "application/pdf";
+          var rootEntryId = 1;
           const request = new ImportEntryRequest();
           request.autoRename = true;
-          request.name = "sample.pdf";
-          let response: StartTaskResponse = await _RepositoryApiClient.entriesClient.startImport({
-            fileName: "sample.pdf",
-            fileSizeInBytes: 63096545,
-            mimeType: "application/pdf",
+          request.name = name;
+          var metadata ={
+            templateName: templateName,
+            tags: [tagName]
+          };
+      
+          request.metadata = ImportAsyncMetadata.fromJS(metadata);
+          let response: StartTaskResponse = await _RepositoryApiClient.entriesClient.startImportEntry({
             repositoryId,
-            entryId: 1,
+            entryId: rootEntryId,
             file: edoc,
+            fileSizeInBytes: 63096545,
+            mimeType: mimeType,
             request: request
         });
-        await new Promise((r) => setTimeout(r, 30000));
 
         var response2 = await _RepositoryApiClient.tasksClient.listTasks({
             repositoryId,
@@ -46,10 +56,23 @@ describe('Large File Import Integration Tests', () => {
         expect(response2.value!.length).toBeGreaterThan(0);
     
         let taskProgress = response2.value![0];
-        console.log(response2);
-        console.log(taskProgress.errors);
         expect(taskProgress.status).toBe(TaskStatus.Completed);
         expect(taskProgress.percentComplete).toBe(100);
-      });
+        let createdEntryId = taskProgress.result?.entryId;
+        var createdEntry = await _RepositoryApiClient.entriesClient.getEntry({repositoryId: repositoryId, entryId: createdEntryId!});
+        expect(createdEntry).not.toBeNull();
+        expect(createdEntry.id).toEqual(createdEntryId);
+        expect(createdEntry.name).toEqual(name);
+        expect(createdEntry.isContainer).toBeFalsy();
+        expect(createdEntry.isLeaf).toBeTruthy();
+        expect(createdEntry.parentId).toEqual(rootEntryId);
+        
+        // Verify the created entry's templateName
+        expect(createdEntry.templateName).toEqual(templateName);
 
+        // Verify the created entry's tag
+        var tags = await _RepositoryApiClient.entriesClient.listTags({repositoryId: repositoryId, entryId: createdEntryId!});
+        expect(tags.value?.length).toEqual(1);
+        expect(tags.value![0].name).toEqual(tagName);
+      });
   });

--- a/test/Entries/LargeFileImport.test.ts
+++ b/test/Entries/LargeFileImport.test.ts
@@ -2,49 +2,57 @@ import { repositoryId } from '../TestHelper.js';
 import { _RepositoryApiClient } from '../CreateSession.js';
 import 'isomorphic-fetch';
 import { Blob as NodeBlob } from 'buffer';
-import { FileParameter, ImportAsyncMetadata, ImportEntryRequest, StartTaskResponse, TaskStatus } from '../../src/index.js';
+import { AuditEventType, ExportEntryRequestPart, FileParameter, ImportAsyncMetadata, ImportEntryRequest, StartExportEntryRequest, StartTaskResponse, TaskStatus } from '../../src/index.js';
 import { isBrowser } from '@laserfiche/lf-js-utils/dist/utils/core-utils.js';
 
 describe('Large File Import Integration Tests', () => {
 
       test('Importing a 60MB file with assigning a template and tag is successful', async () => {
         let blob: any;
+        let edoc : FileParameter;
         if (isBrowser()){
-            blob = new Blob([""], {
-                type: "application/json",
-              });
+          var fakeFileSizeInMB = 123;
+          var fakeFileSizeInBytes = fakeFileSizeInMB * 1024 * 1024 + 3455; // Not used a round value for file size.
+          const buffer = new ArrayBuffer(fakeFileSizeInBytes);
+          blob = new Blob([buffer], {
+            type: "application/pdf",
+          });
+          edoc = {
+            fileName: "FakeFile.pdf",
+            data: blob
+          }
         } else {
-            blob = new NodeBlob([""], {
-                type: "application/json",
-              });
-        }
-        const edoc : FileParameter = {
+          blob = new NodeBlob([""], {
+            type: "application/json",
+          });
+          edoc = {
             fileName: "test/Entries/sampleFiles/60MB.pdf",
             data: blob
           }
+        }
 
-          var fileName = "sample";
-          var fileExtension = "pdf";
-          var name = `${fileName}.${fileExtension}`;
-          var templateName = "Email";
-          var tagName = "TestTag";
-          var mimeType = "application/pdf";
-          var rootEntryId = 1;
-          const request = new ImportEntryRequest();
-          request.autoRename = true;
-          request.name = name;
-          var metadata ={
-            templateName: templateName,
-            tags: [tagName]
-          };
-      
-          request.metadata = ImportAsyncMetadata.fromJS(metadata);
-          let response: StartTaskResponse = await _RepositoryApiClient.entriesClient.startImportEntry({
-            repositoryId,
-            entryId: rootEntryId,
-            file: edoc,
-            mimeType: mimeType,
-            request: request
+        var fileName = "sample";
+        var fileExtension = "pdf";
+        var name = `${fileName}.${fileExtension}`;
+        var templateName = "Email";
+        var tagName = "TestTag";
+        var mimeType = "application/pdf";
+        var rootEntryId = 1;
+        const request = new ImportEntryRequest();
+        request.autoRename = true;
+        request.name = name;
+        var metadata ={
+          templateName: templateName,
+          tags: [tagName]
+        };
+    
+        request.metadata = ImportAsyncMetadata.fromJS(metadata);
+        let response: StartTaskResponse = await _RepositoryApiClient.entriesClient.startImportEntry({
+          repositoryId,
+          entryId: rootEntryId,
+          file: edoc,
+          mimeType: mimeType,
+          request: request
         });
 
         var response2 = await _RepositoryApiClient.tasksClient.listTasks({

--- a/test/Entries/LargeFileImport.test.ts
+++ b/test/Entries/LargeFileImport.test.ts
@@ -7,7 +7,7 @@ import { isBrowser } from '@laserfiche/lf-js-utils/dist/utils/core-utils.js';
 
 describe('Large File Import Integration Tests', () => {
 
-      test('Importing a 60MB file is successful', async () => {
+      test('Importing a 60MB file with assigning a template and tag is successful', async () => {
         let blob: any;
         if (isBrowser()){
             blob = new Blob([""], {
@@ -23,7 +23,9 @@ describe('Large File Import Integration Tests', () => {
             data: blob
           }
 
-          var name = "sample.pdf";
+          var fileName = "sample";
+          var fileExtension = "pdf";
+          var name = `${fileName}.${fileExtension}`;
           var templateName = "Email";
           var tagName = "TestTag";
           var mimeType = "application/pdf";
@@ -62,11 +64,12 @@ describe('Large File Import Integration Tests', () => {
         var createdEntry = await _RepositoryApiClient.entriesClient.getEntry({repositoryId: repositoryId, entryId: createdEntryId!});
         expect(createdEntry).not.toBeNull();
         expect(createdEntry.id).toEqual(createdEntryId);
-        expect(createdEntry.name).toEqual(name);
+        expect(createdEntry.name?.startsWith(fileName)).toBeTruthy(); // As autoRename is true, the name of the created entry is not exactly the same as the given name, e.g. it can be 'sample (5).pdf'
+        expect(createdEntry.name?.endsWith(fileExtension)).toBeTruthy(); 
         expect(createdEntry.isContainer).toBeFalsy();
         expect(createdEntry.isLeaf).toBeTruthy();
         expect(createdEntry.parentId).toEqual(rootEntryId);
-        
+
         // Verify the created entry's templateName
         expect(createdEntry.templateName).toEqual(templateName);
 


### PR DESCRIPTION
A helper function `startImportEntry` is added to the EntriesClient (this is named after the `startExportEntry` as this function also returns a taskId):
It takes a file and iteratively makes a call to `CreateMultipartUploadUrls` api to get a batch of 10 URLs, and then, reads 100 MB chunks from the file and writes them to the URLs. If EOF is reached when reading the 100MB from the file, the rest of the created URLs are not used.
- In each call to this api, it requests up to 10 URLs, e.g. for a 2 GB file, it will make 2 calls to `CreateMultipartUploadUrls` API.
Finally, it calls the `ImportUploadedParts` API to import the entry.

**Notes:** 
- When writing each 100MB part, the whole 100MB of data is read to a single buffer in memory and then written to the HTTP request's connection. This can be improved later to iteratively read/write smaller pieces of data to better use the memory.
- An integration test is added that includes assigning template and tag metadata to the entry.