### PR TITLE
Additional changes for v1 branch restructure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ on:
   workflow_dispatch:
 
 env:
+  API_VERSION: 'v1'
   NPM_VERSION: '1.1.4'
   GITHUB_PAGES_BRANCH: 'gh-pages'
 
@@ -133,17 +134,17 @@ jobs:
         run: npm install typedoc
 
       - name: Create temporary directory
-        run: mkdir -p ./docs_temp/${{ github.ref_name }}
+        run: mkdir -p ./docs_temp
 
       - name: Generate typedoc docs
-        run: npx typedoc ./src/index.ts --out ./docs_temp/${{ github.ref_name }} --excludePrivate --includeVersion
+        run: npx typedoc ./src/index.ts --out ./docs_temp --excludePrivate --includeVersion
 
       - name: Upload a build artifact
         uses: actions/upload-artifact@v2.3.1
         with:
           name: documentation-artifact
           # A file, directory or wildcard pattern that describes what to upload
-          path: ${{ github.workspace }}/docs_temp/${{ github.ref_name }}
+          path: ${{ github.workspace }}/docs_temp
 
       - name: Delete temporary directory
         run: rm -r ./docs_temp
@@ -193,7 +194,7 @@ jobs:
       - name: Tag commit
         uses: rickstaa/action-create-tag@v1
         with:
-          tag: ${{ env.NpmPackageVersion }}
+          tag: ${{ env.API_VERSION }}-${{ env.NpmPackageVersion }}
           commit_sha: ${{ github.sha }}
           message: Workflow run ${{github.server_url}}/${{github.repository}}/actions/runs/${{ github.run_id}}
 
@@ -239,7 +240,7 @@ jobs:
       - name: Tag commit
         uses: rickstaa/action-create-tag@v1
         with:
-          tag: ${{ env.NPM_VERSION }}
+          tag: ${{ env.API_VERSION }}-${{ env.NPM_VERSION }}
           commit_sha: ${{ github.sha }}
           message: Workflow run ${{github.server_url}}/${{github.repository}}/actions/runs/${{ github.run_id}}
 
@@ -251,41 +252,36 @@ jobs:
     steps:
       - name: Set DOCUMENTATION_VERSION environment variable
         run: |
-          if [[ '${{ github.event_name }}' == 'pull_request' ]]; then
-            echo 'DOCUMENTATION_VERSION=${{ github.base_ref }}' >> $GITHUB_ENV
-          elif [[ '${{ github.ref_protected }}' == 'true' && '${{ github.ref_type }}' == 'branch' ]]; then
-            echo 'DOCUMENTATION_VERSION=${{ github.ref_name }}' >> $GITHUB_ENV
-          else
-            echo '::error::Unable to publish documentation for the current branch.'
-            exit 1
-          fi
-
+          npm_version=${{ env.NPM_VERSION }}
+          major_version=${npm_version%%.*}
+          documentation_version=$major_version.x
+          echo $documentation_version
+          echo DOCUMENTATION_VERSION=$documentation_version >> $GITHUB_ENV
       - name: Print DOCUMENTATION_VERSION environment variable
         run: |
-          echo 'Publishing documentation to ${{ env.GITHUB_PAGES_BRANCH }} for ${{ env.DOCUMENTATION_VERSION }}.'
-
+          echo 'Publishing documentation to ${{ env.GITHUB_PAGES_BRANCH }} for ${{ env.API_VERSION }} ${{ env.DOCUMENTATION_VERSION }}.'
       - uses: actions/checkout@v3
         with:
           ref: ${{ env.GITHUB_PAGES_BRANCH }}
 
       - name: Delete documentation directory
-        run: rm -f -r ./docs/${{ env.DOCUMENTATION_VERSION }}
+        run: rm -f -r ./docs/${{ env.API_VERSION }}/${{ env.DOCUMENTATION_VERSION }}
 
       - name: Create documentation directory
-        run: mkdir -p ./docs/${{ env.DOCUMENTATION_VERSION }}
+        run: mkdir -p ./docs/${{ env.API_VERSION }}/${{ env.DOCUMENTATION_VERSION }}
 
       - name: Download documentation build artifact
         uses: actions/download-artifact@v3.0.0
         with:
           name: documentation-artifact
-          path: ./docs/${{ env.DOCUMENTATION_VERSION }}
+          path: ./docs/${{ env.API_VERSION }}/${{ env.DOCUMENTATION_VERSION }}
 
-      - name: Create pull request
+      - name: Create a pull request
         uses: peter-evans/create-pull-request@v4.2.3
         with:
-          branch: ${{ env.GITHUB_PAGES_BRANCH }}-${{ env.DOCUMENTATION_VERSION }}-patch
+          branch: ${{ env.GITHUB_PAGES_BRANCH }}-${{ env.API_VERSION }}-${{ env.DOCUMENTATION_VERSION }}-patch
           delete-branch: true
-          title: "Automated documentation update for ${{ env.DOCUMENTATION_VERSION }} by action ${{ github.run_id }}"
-          commit-message: "Automated documentation update for ${{ env.DOCUMENTATION_VERSION }} by action ${{ github.run_id }}"
-          body: "Automated documentation update for ${{ env.DOCUMENTATION_VERSION }} by action ${{ github.run_id }}"
+          title: "Automated documentation update for ${{ env.API_VERSION }} ${{ env.DOCUMENTATION_VERSION }} by action ${{ github.run_id }}"
+          commit-message: "Automated documentation update for ${{ env.API_VERSION }} ${{ env.DOCUMENTATION_VERSION }} by action ${{ github.run_id }}"
+          body: "Automated documentation update for ${{ env.API_VERSION }} ${{ env.DOCUMENTATION_VERSION }} by action ${{ github.run_id }}"
           assignees: ${{ github.actor }}

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Use the Laserfiche Repository API to access data in a Laserfiche repository. Imp
 
 ## Changelog
 
-See CHANGELOG [here](https://github.com/Laserfiche/lf-repository-api-client-js/blob/HEAD/CHANGELOG.md).
+See CHANGELOG [here](https://github.com/Laserfiche/lf-repository-api-client-js/blob/v1/CHANGELOG.md).
 
 ## Installation
 
@@ -17,7 +17,7 @@ To install, [see here](https://www.npmjs.com/package/@laserfiche/lf-repository-a
 
 ### Build, Test, and Package
 
-See the [.github/workflows/main.yml](https://github.com/Laserfiche/lf-repository-api-client-js/blob/HEAD/.github/workflows/main.yml).
+See the [.github/workflows/main.yml](https://github.com/Laserfiche/lf-repository-api-client-js/blob/v1/.github/workflows/main.yml).
 
 #### Branches
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Use the Laserfiche Repository API to access data in a Laserfiche repository. Imp
 ## Documentation
 
 - [Developer Documentation](https://developer.laserfiche.com/)
-- [JS Repository API Client Lib Documentation](https://laserfiche.github.io/lf-repository-api-client-js/)
+- [Documentation](https://laserfiche.github.io/lf-repository-api-client-js/docs/v1/index.html) for the `@laserfiche/lf-repository-api-client` npm package used to access the v1 Laserfiche Repository APIs.
 
 ## Changelog
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@laserfiche/lf-repository-api-client",
   "type": "module",
   "version": "1.1.4",
-  "description": "Laserfiche Repository API Client library for TypeScript.",
+  "description": "The TypeScript Laserfiche Repository API Client library for accessing the v1 Laserfiche Repository APIs.",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "files": [


### PR DESCRIPTION
- Update the publish documentation pipeline step to include the api version (ie v1, v2) in the folder path
- Update the tag name when publishing new packages to include the api version
- Update the README to include links to both the v1 documentation and fix links to the changelog and pipeline